### PR TITLE
Move Regfile out of ID Stage Module

### DIFF
--- a/src/id_stage.v
+++ b/src/id_stage.v
@@ -1,16 +1,16 @@
 // stage-level module
 module id_stage (
-    input clk,              // one clock cycle: 0 -> 1
-    input rst_n,            // reset when 0
-
-    // inputs from higher level module
-    input wr_n,             // regfile write enable: allow write when 0
-    input [4:0] wr_addr,    // write address of regfile
-    input [31:0] data_in,   // data to write into wr_addr
-
     // inputs from IF stage
     input [31:0] pc_from_if,
     input [31:0] ir,
+
+    // outputs to Register File
+    output [4:0] rs1,
+    output [4:0] rs2,
+
+    // inputs from Register File (read)
+    input [31:0] data1_from_regfile,
+    input [31:0] data2_from_regfile,
 
     // outputs to EX stage
     output [31:0] pc_to_ex,
@@ -22,9 +22,6 @@ module id_stage (
     output [31:0] imm,
     output [4:0] rd
 );
-
-    wire [4:0] rs1;
-    wire [4:0] rs2;
 
     ir_splitter ir_splitter_inst(
         .ir(ir),
@@ -50,24 +47,13 @@ module id_stage (
         .out(imm)
     );
 
-    // NOTE: not a good idea to have an instance of register file inside ID stage,
-    // as the same instance need to be accessed during WB stage
-    rf32x32 regfile32_inst(
-        .clk(clk),
-        .reset(rst_n),
-        .wr_n(wr_n),
-        .rd1_addr(rs1),
-        .rd2_addr(rs2),
-        .wr_addr(wr_addr),
-        .data_in(data_in),
-        .data1_out(data1),
-        .data2_out(data2)
-    );
-
     // direct pc_from_if to pc_to_ex
     // NOTE: might not be a good idea to pass pc directly
     // pc read at IF stage might overwrite
     // (old) pc that are passed over other stages.
     assign pc_to_ex = pc_from_if;
+
+    assign data1 = data1_from_regfile;
+    assign data2 = data2_from_regfile;
 
 endmodule

--- a/test/test_id_stage.v
+++ b/test/test_id_stage.v
@@ -1,13 +1,12 @@
 module test_id_stage ();
-    reg clk;
-    reg rst_n;
-
-    reg wr_n;
-    reg [4:0] wr_addr;
-    reg [31:0] data_in;
-
     reg [31:0] pc_from_if;
     reg [31:0] ir;
+
+    wire [4:0] rs1;
+    wire [4:0] rs2;
+
+    reg [31:0] data1_from_regfile;
+    reg [31:0] data2_from_regfile;
 
     wire [31:0] pc_to_ex;
     wire [6:0] opcode;
@@ -17,13 +16,12 @@ module test_id_stage ();
     wire [4:0] rd;
 
     id_stage subject(
-        .clk(clk),
-        .rst_n(rst_n),
-        .wr_n(wr_n),
-        .wr_addr(wr_addr),
-        .data_in(data_in),
         .pc_from_if(pc_from_if),
         .ir(ir),
+        .rs1(rs1),
+        .rs2(rs2),
+        .data1_from_regfile(data1_from_regfile),
+        .data2_from_regfile(data2_from_regfile),
         .pc_to_ex(pc_to_ex),
         .opcode(opcode),
         .funct3(funct3),
@@ -35,42 +33,22 @@ module test_id_stage ();
     );
 
     initial begin
-        // initial state
-        assign rst_n = 1'b1;
-
         //
         // Setup
         //
-
-        // write some data into regfile
-        assign wr_n = 1'b0;
-        // cycle 1
-        assign clk = 1'b0;
-        assign wr_addr = 5'd1;
-        assign data_in = 32'd1;
-        #5
-        assign clk = ~clk;
-        #5
-        // cycle 2
-        assign clk = ~clk;
-        assign wr_addr = 5'd2;
-        assign data_in = 32'd2;
-        #5
-        assign clk = ~clk;
-        assign wr_n = 1'b1;
-        assign wr_addr = 32'b0; // clear wr_data (reg0 is read-only)
-        assign data_in = 32'b0; // clear data_in
-        #5
+        assign data1_from_regfile = 32'd1;
+        assign data2_from_regfile = 32'd2;
 
         //
         // Test
         //
 
         // ADD r3, r1, r2
-        assign clk = ~clk;
         assign pc_from_if = 32'd4;  // any multiple of 4 will do
         assign ir = 32'b0000000_00010_00001_000_00011_0110011;
         // expect
+        // rs1: 1
+        // rs2: 2
         // pc_to_ex: 4
         // opcode: 0110011
         // funct3: 000
@@ -82,10 +60,11 @@ module test_id_stage ();
         #5
 
         // ADDI r3, r1, 12'h801
-        assign clk = ~clk;
         assign pc_from_if = 32'd8;
         assign ir = 32'b1000_0000_0001_00001_000_00011_0010011;
         // expect
+        // rs1: 1
+        // rs2: 2
         // pc_to_ex: 8
         // opcode: 0010011
         // funct3: 000


### PR DESCRIPTION
Regfile will be used by WB Stage too, so it might be better to have Regfile outside of ID Stage Module.
Being outside of ID Stage Module, regfile will be controlled by a higher-level module.