### PR TITLE
Basic Logic Synthesis

### DIFF
--- a/logical_synthesis_ground/logical_synthesis.tcl
+++ b/logical_synthesis_ground/logical_synthesis.tcl
@@ -51,7 +51,7 @@ read_verilog mem_wb_regs.v
 read_verilog pc_reg.v
 read_verilog rf32x32.v
 read_verilog stall_detector.v
-read_verilog wb_stage.
+read_verilog wb_stage.v
 
 # Top Module
 read_verilog top.v

--- a/logical_synthesis_ground/logical_synthesis.tcl
+++ b/logical_synthesis_ground/logical_synthesis.tcl
@@ -77,7 +77,7 @@ set_input_delay 0.0 -clock clk [remove_from_collection [all_inputs] clk]
 set_output_delay 0.0 -clock clk [remove_from_collection [all_outputs] clk]
 
 # Start Logical Synthesis
-compile -map_effort mediium -area_effort high -incremental_mapping
+compile -map_effort medium -area_effort high -incremental_mapping
 
 # Show results
 report_timing -max_paths 1

--- a/logical_synthesis_ground/logical_synthesis.tcl
+++ b/logical_synthesis_ground/logical_synthesis.tcl
@@ -5,54 +5,6 @@ set link_library $LIB_MAX_FILE
 set target_library $LIB_MAX_FILE
 
 # Read Verilog Modules
-# NOTE: need to read low-level modules first
-
-# Modules in IF stage
-read_verilog pc_adder.v
-read_verilog if_ctrl.v
-
-# Modules in ID stage
-read_verilog ir_splitter.v
-read_verilog imm_extractor.v
-
-# Modules in EX stage
-read_verilog ex_ctrl.v
-read_verilog alu.v
-read_verilog branch_alu.v
-
-# Modules in MEM stage
-read_verilog mem_ctrl.v
-read_verilog st_converter.v
-read_verilog ld_converter.v
-
-# Modules in WB stage
-read_verilog wb_ctrl.v
-
-# Module used by rf32x32.v
-read_verilog DW_ram_2r_w_s_dff.v
-
-# Modules in Top Module
-read_verilog data_forward_helper.v
-read_verilog data_forward_u.v
-read_verilog ex_data_picker.v
-read_verilog ex_jump_picker.v
-read_verilog ex_mem_regs.v
-read_verilog ex_stage.v
-read_verilog flush_u.v
-read_verilog id_data_picker.v
-read_verilog id_ex_regs.v
-read_verilog id_flush_picker.v
-read_verilog id_stage.v
-read_verilog id_wr_reg_n_picker.v
-read_verilog if_id_regs.v
-read_verilog if_stage.v
-read_verilog mem_stage.v
-read_verilog mem_wb_regs.v
-read_verilog pc_reg.v
-read_verilog rf32x32.v
-read_verilog stall_detector.v
-read_verilog wb_stage.v
-
 # Top Module
 read_verilog top.v
 
@@ -83,6 +35,7 @@ compile -map_effort medium -area_effort high -incremental_mapping
 report_timing -max_paths 1
 report_area
 report_power
+report_constraint -all_violators
 
 write -hier -format verilog -output rv32_processor.vnet
 write -hier -output rv32_processor.db

--- a/logical_synthesis_ground/logical_synthesis.tcl
+++ b/logical_synthesis_ground/logical_synthesis.tcl
@@ -6,7 +6,12 @@ set target_library $LIB_MAX_FILE
 
 # Read Verilog Modules
 # Top Module
-read_verilog top.v
+read_verilog ./top.v
+# Analyze and Elaborate Parameterized Modules
+analyze -format verilog ./data_forward_helper.v
+elaborate data_forward_helper
+analyze -format verilog ./DW_ram_2r_w_s_dff.v
+elaborate DW_ram_2r_w_s_dff
 
 # Define which module is the Highest-level Module
 current_design "top"

--- a/logical_synthesis_ground/logical_synthesis.tcl
+++ b/logical_synthesis_ground/logical_synthesis.tcl
@@ -1,0 +1,90 @@
+# Get the program needed for Logical Synthesis
+set search_path [concat "/usr/local/lib/hit18-lib/kyoto_lib/synopsys/" $search_path]
+set LIB_MAX_FILE {HIT018.db}
+set link_library $LIB_MAX_FILE
+set target_library $LIB_MAX_FILE
+
+# Read Verilog Modules
+# NOTE: need to read low-level modules first
+
+# Modules in IF stage
+read_verilog pc_adder.v
+read_verilog if_ctrl.v
+
+# Modules in ID stage
+read_verilog ir_splitter.v
+read_verilog imm_extractor.v
+
+# Modules in EX stage
+read_verilog ex_ctrl.v
+read_verilog alu.v
+read_verilog branch_alu.v
+
+# Modules in MEM stage
+read_verilog mem_ctrl.v
+read_verilog st_converter.v
+read_verilog ld_converter.v
+
+# Modules in WB stage
+read_verilog wb_ctrl.v
+
+# Module used by rf32x32.v
+read_verilog DW_ram_2r_w_s_dff.v
+
+# Modules in Top Module
+read_verilog data_forward_helper.v
+read_verilog data_forward_u.v
+read_verilog ex_data_picker.v
+read_verilog ex_jump_picker.v
+read_verilog ex_mem_regs.v
+read_verilog ex_stage.v
+read_verilog flush_u.v
+read_verilog id_data_picker.v
+read_verilog id_ex_regs.v
+read_verilog id_flush_picker.v
+read_verilog id_stage.v
+read_verilog id_wr_reg_n_picker.v
+read_verilog if_id_regs.v
+read_verilog if_stage.v
+read_verilog mem_stage.v
+read_verilog mem_wb_regs.v
+read_verilog pc_reg.v
+read_verilog rf32x32.v
+read_verilog stall_detector.v
+read_verilog wb_stage.
+
+# Top Module
+read_verilog top.v
+
+# Define which module is the Highest-level Module
+current_design "top"
+
+# Max Area of Circuits
+set_max_area 0
+
+# Max Fan-out
+# From Wikipedia,
+# The greatest number of inputs of gates of the same type to which
+# the output can be safely connected.
+# NOTE: Google Image "fanout" for better idea
+set_max_fanout 64 [current_design]
+
+# Create Clock
+create_clock -period 10.00 clk
+set_clock_uncertainty -setup 0.0 [get_clock clk]
+set_clock_uncertainty -hold 0.0 [get_clock clk]
+set_input_delay 0.0 -clock clk [remove_from_collection [all_inputs] clk]
+set_output_delay 0.0 -clock clk [remove_from_collection [all_outputs] clk]
+
+# Start Logical Synthesis
+compile -map_effort mediium -area_effort high -incremental_mapping
+
+# Show results
+report_timing -max_paths 1
+report_area
+report_power
+
+write -hier -format verilog -output rv32_processor.vnet
+write -hier -output rv32_processor.db
+
+quit

--- a/logical_synthesis_ground/logical_synthesis.tcl
+++ b/logical_synthesis_ground/logical_synthesis.tcl
@@ -6,17 +6,21 @@ set target_library $LIB_MAX_FILE
 
 # Read Verilog Modules
 # Top Module
-read_verilog ./top.v
+# read_verilog ./top.v
 # Analyze and Elaborate Parameterized Modules
 analyze -format verilog ./data_forward_helper.v
 elaborate data_forward_helper
 analyze -format verilog ./DW_ram_2r_w_s_dff.v
 elaborate DW_ram_2r_w_s_dff
+analyze -format verilog ./top.v
+elaborate top
 
 # Define which module is the Highest-level Module
 current_design "top"
 
 # Max Area of Circuits
+# Usually speed is more important, so just aim for the best area
+# by setting max_area to 0
 set_max_area 0
 
 # Max Fan-out
@@ -33,8 +37,17 @@ set_clock_uncertainty -hold 0.0 [get_clock clk]
 set_input_delay 0.0 -clock clk [remove_from_collection [all_inputs] clk]
 set_output_delay 0.0 -clock clk [remove_from_collection [all_outputs] clk]
 
+# Check if Clock is created
+derive_clocks
+
 # Start Logical Synthesis
-compile -map_effort medium -area_effort high -incremental_mapping
+compile
+ungroup -all -flatten
+compile -incremental
+# compile -map_effort medium -area_effort high -incremental_mapping
+
+# Check Design
+check_design
 
 # Show results
 report_timing -max_paths 1

--- a/script/cp_from_src_to_logical_synthesis_ground.sh
+++ b/script/cp_from_src_to_logical_synthesis_ground.sh
@@ -1,0 +1,3 @@
+# shell
+
+cp src/*.v logical_synthesis_ground/

--- a/script/logical_synthesis.py
+++ b/script/logical_synthesis.py
@@ -1,0 +1,22 @@
+# python3
+
+import subprocess
+
+if __name__ == "__main__":
+    # Copy from src/ to logical_synthesis_ground
+    print("copying src files to logical_synthesis_ground")
+    copy_command = f"sh script/cp_from_src_to_logical_synthesis_ground.sh".split()
+    copy_result = subprocess.run(copy_command)
+    if copy_result.returncode != 0:
+        return_code = copy_result.returncode
+        print(f'Copy failed with code: {return_code}')
+        exit(return_code)
+
+    # Perform Logical Synthesis
+    print('start logical synthesis')
+    synthesis_command = f"sh script/run_logical_synthesis.sh".split()
+    synthesis_result = subprocess.run(synthesis_command)
+    if synthesis_result.returncode != 0:
+        return_code = synthesis_result.returncode
+        print(f'Logical Synthesis failed with code: {return_code}')
+        exit(return_code)

--- a/script/run_logical_synthesis.sh
+++ b/script/run_logical_synthesis.sh
@@ -1,0 +1,7 @@
+# shell
+
+cd logical_synthesis_ground/
+
+dc_shell-t -f logical_synthesis.tcl | tee log
+
+cd ~/sandbox

--- a/src/alu.v
+++ b/src/alu.v
@@ -12,15 +12,15 @@ module alu (
         reg signed [31:0] s_in2;
 
         begin
-            s_in1 = in1;
-            s_in2 = in2;
+            s_in1 = $signed(in1);
+            s_in2 = $signed(in2);
 
             case (alu_op)
                 // ADD, ADDI, Load, Store, Branch, JAL, AUIPC
-                4'b0000: alu_out = s_in1 + s_in2;
+                4'b0000: alu_out = in1 + in2;
 
                 // SLL, SLLI
-                4'b0001: alu_out = s_in1 << { 27'b0, in2[4:0] };
+                4'b0001: alu_out = in1 << { 27'b0, in2[4:0] };
 
                 // SLT, SLTI
                 4'b0010: alu_out = (s_in1 < s_in2) ? 32'd1 : 32'd0;
@@ -32,7 +32,7 @@ module alu (
                 4'b0100: alu_out = in1 ^ in2;
 
                 // SRL, SRLI
-                4'b0101: alu_out = s_in1 >> { 27'b0, in2[4:0] };
+                4'b0101: alu_out = in1 >> { 27'b0, in2[4:0] };
 
                 // OR, ORI
                 4'b0110: alu_out = in1 | in2;
@@ -41,15 +41,17 @@ module alu (
                 4'b0111: alu_out = in1 & in2;
 
                 // SUB
-                4'b1000: alu_out = s_in1 - s_in2;
+                4'b1000: alu_out = in1 - in2;
 
                 // LUI
                 4'b1001: alu_out = in2;
 
                 // JALR
+                // signed to unsigned assignment occurs. (VER-318)
                 4'b1010: alu_out = (in1 + in2) & ~1;
 
                 // SRA, SRAI
+                // signed to unsigned assignment occurs. (VER-318)
                 4'b1101: alu_out = s_in1 >>> { 27'b0, in2[4:0] };
 
                 // default: false

--- a/src/branch_alu.v
+++ b/src/branch_alu.v
@@ -47,9 +47,7 @@ module branch_alu (
                 // GEU
                 3'b111: branch_alu_out = (in1 >= in2) ? 1'b1 : 1'b0;
 
-                // all cases covered, so no default value is required
-                // default: false (don't branch / jump just in case something went wrong)
-                default: branch_alu_out = 1'b0;
+                // no default case as every case is covered
             endcase 
         end        
     endfunction    

--- a/src/branch_alu.v
+++ b/src/branch_alu.v
@@ -15,19 +15,13 @@ module branch_alu (
     // functions
     //
     function branch_alu_out(input [31:0] in1, input [31:0] in2, input [2:0] op);
-        reg signed [31:0] s_in1;
-        reg signed [31:0] s_in2;
-
         begin
-            s_in1 = in1;
-            s_in2 = in2;
-
             case (op)
                 // EQ
-                3'b000: branch_alu_out = (in1 == in2) ? 1'b1 : 1'b0;
+                3'b000: branch_alu_out = (in1 == in2);
 
                 // NE
-                3'b001: branch_alu_out = (in1 != in2) ? 1'b1: 1'b0;
+                3'b001: branch_alu_out = (in1 != in2);
 
                 // JAL, JALR
                 3'b010: branch_alu_out = 1'b1;
@@ -36,16 +30,16 @@ module branch_alu (
                 3'b011: branch_alu_out = 1'b0;
 
                 // LT
-                3'b100: branch_alu_out = (s_in1 < s_in2) ? 1'b1 : 1'b0;
+                3'b100: branch_alu_out = ($signed(in1) < $signed(in2));
 
                 // GE
-                3'b101: branch_alu_out = (s_in1 >= s_in2) ? 1'b1 : 1'b0;
+                3'b101: branch_alu_out = ($signed(in1) >= $signed(in2));
 
                 // LTU
-                3'b110: branch_alu_out = (in1 < in2) ? 1'b1 : 1'b0;
+                3'b110: branch_alu_out = (in1 < in2);
 
                 // GEU
-                3'b111: branch_alu_out = (in1 >= in2) ? 1'b1 : 1'b0;
+                3'b111: branch_alu_out = (in1 >= in2);
 
                 // no default case as every case is covered
             endcase 

--- a/src/data_forward_helper.v
+++ b/src/data_forward_helper.v
@@ -10,19 +10,20 @@
 // JALR     : x[rd] <- PC + 4 => sub_data
 // Branch   : doesn't update => X
 //
-module data_forward_helper (
+module data_forward_helper
+#(
+    parameter IS_MEM_STAGE = 1  // 0: ex, 1: mem
+) (
     input [31:0] main_data,
     input [31:0] sub_data,
     input [6:0] opcode,
-    input is_mem_stage,  // 0: ex, 1: mem
     output [31:0] data_to_forward
 );
-
     //
     // Main
     //
     
-    assign data_to_forward = prep_data_to_forward(main_data, sub_data, opcode, is_mem_stage);
+    assign data_to_forward = prep_data_to_forward(main_data, sub_data, opcode, IS_MEM_STAGE);
 
     //
     // Functions

--- a/src/ex_ctrl.v
+++ b/src/ex_ctrl.v
@@ -106,9 +106,7 @@ module ex_ctrl (
                     // AND, ANDI
                     3'b111: alu_op_ctrl = { 1'b0, funct3 };
 
-                    // all case covered
-                    // default: most instructions perform ADD
-                    default: alu_op_ctrl = 4'b0000;
+                    // no default case as every case is covered
                 endcase
             end else begin
                 // AUIPC, JAL, Branch, Load, Store

--- a/src/ex_mem_regs.v
+++ b/src/ex_mem_regs.v
@@ -37,16 +37,7 @@ module ex_mem_regs (
     reg flush;
 
     always @(posedge clk or negedge rst_n) begin
-        if (rst_n) begin
-            pc4 <= pc4_in;
-            b <= b_in;
-            c <= c_in;
-            funct3 <= funct3_in;
-            rd <= rd_in;
-            opcode <= opcode_in;
-            wr_reg_n <= wr_reg_n_in;
-            flush <= flush_in;
-        end else begin
+        if (!rst_n) begin
             pc4 <= 32'bx;
             b <= 32'bx;
             c <= 32'bx;
@@ -55,6 +46,15 @@ module ex_mem_regs (
             opcode <= 7'bx;
             wr_reg_n <= 1'b1;   // default not to write
             flush <= 1'b0;      // default not to flush
+        end else begin
+            pc4 <= pc4_in;
+            b <= b_in;
+            c <= c_in;
+            funct3 <= funct3_in;
+            rd <= rd_in;
+            opcode <= opcode_in;
+            wr_reg_n <= wr_reg_n_in;
+            flush <= flush_in;
         end
     end
 

--- a/src/id_ex_regs.v
+++ b/src/id_ex_regs.v
@@ -34,7 +34,7 @@ module id_ex_regs (
     output wr_reg_n_out,
 
     input flush_in,
-    input flush_out
+    output flush_out
 );
 
     reg [31:0] pc;

--- a/src/id_ex_regs.v
+++ b/src/id_ex_regs.v
@@ -49,9 +49,23 @@ module id_ex_regs (
     reg flush;
 
     always @(posedge clk or negedge rst_n) begin
-        if (!rst_n || stall) begin
+        if (!rst_n) begin
             // reset
             // same behavior as reset when stall
+            pc <= 32'bx;
+            pc4 <= 32'bx;
+            data1 <= 32'bx;
+            data2 <= 32'bx;
+            funct7 <= 7'bx;
+            funct3 <= 3'bx;
+            rs2 <= 5'bx;
+            rd <= 5'bx;
+            opcode <= 7'bx;
+            imm <= 32'bx;
+            wr_reg_n <= 1'b1;   // default not to write
+            flush <= 1'b0;      // default not to flush
+        end else if (stall) begin
+            // stall has same behaviour as reset
             pc <= 32'bx;
             pc4 <= 32'bx;
             data1 <= 32'bx;

--- a/src/ld_converter.v
+++ b/src/ld_converter.v
@@ -49,7 +49,7 @@ module ld_converter (
         reg [7:0] data;
 
         begin
-            assign data = in[7:0];
+            data = in[7:0];
 
             if (s_ext) ld_ext_b = { { 24{data[7]} }, data };
             else ld_ext_b = { 24'b0, data };
@@ -60,7 +60,7 @@ module ld_converter (
         reg [15:0] data;
 
         begin
-            assign data = in[15:0];
+            data = in[15:0];
 
             if (s_ext) ld_ext_h = { { 16{data[15]} }, data };
             else ld_ext_h = { { 16'b0 }, data };

--- a/src/mem_ctrl.v
+++ b/src/mem_ctrl.v
@@ -22,8 +22,8 @@ module mem_ctrl (
         reg is_load, is_store;
 
         begin
-            assign is_load = (opcode == 7'b0000011);
-            assign is_store = (opcode == 7'b0100011);
+            is_load = (opcode == 7'b0000011);
+            is_store = (opcode == 7'b0100011);
 
             if (is_load) begin
                 case (funct3[1:0])
@@ -66,7 +66,7 @@ module mem_ctrl (
         reg is_store;
 
         begin
-            assign is_store = (opcode == 7'b0100011);
+            is_store = (opcode == 7'b0100011);
 
             // don't write when flush
             if (flush) write_ctrl = 1'b0;
@@ -80,8 +80,8 @@ module mem_ctrl (
         reg is_load, is_store;
 
         begin
-            assign is_load = (opcode == 7'b0000011);
-            assign is_store = (opcode == 7'b0100011);
+            is_load = (opcode == 7'b0000011);
+            is_store = (opcode == 7'b0100011);
 
             if (is_load || is_store) mem_access_ctrl = 1'b1;
             else mem_access_ctrl = 1'b0;

--- a/src/mem_stage.v
+++ b/src/mem_stage.v
@@ -11,7 +11,6 @@ module mem_stage (
     input [6:0] opcode,
     input [2:0] funct3,
     input [31:0] b,                 // data to store (Store Instructions)
-    input [31:0] c,                 // memory address to access
     input flush,
 
     // outputs to MEM stage
@@ -27,7 +26,7 @@ module mem_stage (
     // NOTE: need to request for memory access first,
     // then only we will receive data_mem_ready_n from the memory.
 
-    // NOTE: need to think about how to handle data_mem_ready_n
+    // TODO: need to think about how to handle data_mem_ready_n
     mem_ctrl mem_ctrl_inst(
         .opcode(opcode),
         .funct3(funct3),

--- a/src/mem_wb_regs.v
+++ b/src/mem_wb_regs.v
@@ -29,20 +29,20 @@ module mem_wb_regs (
     reg wr_reg_n;
 
     always @(posedge clk or negedge rst_n) begin
-        if (rst_n) begin
-            pc4 <= pc4_in;
-            c <= c_in;
-            d <= d_in;
-            rd <= rd_in;
-            opcode <= opcode_in;
-            wr_reg_n <= wr_reg_n_in;
-        end else begin
+        if (!rst_n) begin
             pc4 <= 32'bx;
             c <= 32'bx;
             d <= 32'bx;
             rd <= 5'bx;
             opcode <= 7'bx;
             wr_reg_n <= 1'b1; // default not to write
+        end else begin
+            pc4 <= pc4_in;
+            c <= c_in;
+            d <= d_in;
+            rd <= rd_in;
+            opcode <= opcode_in;
+            wr_reg_n <= wr_reg_n_in;
         end
     end
 

--- a/src/stall_detector.v
+++ b/src/stall_detector.v
@@ -51,12 +51,12 @@ module stall_detector (
         reg rs1_updated, rs2_updated;
 
         begin
-            assign is_store_in_id = (opcode_in_id == 7'b0100011);
-            assign is_load_in_ex = (opcode_in_ex == 7'b0000011);
-            assign rs1_is_zero = (rs1 == 5'b00000);
-            assign rs2_is_zero = (rs2 == 5'b00000);
-            assign rs1_updated = (!wr_reg_n_in_ex) && (rs1 == rd_in_ex);
-            assign rs2_updated = (!wr_reg_n_in_ex) && (rs2 == rd_in_ex);
+            is_store_in_id = (opcode_in_id == 7'b0100011);
+            is_load_in_ex = (opcode_in_ex == 7'b0000011);
+            rs1_is_zero = (rs1 == 5'b00000);
+            rs2_is_zero = (rs2 == 5'b00000);
+            rs1_updated = (!wr_reg_n_in_ex) && (rs1 == rd_in_ex);
+            rs2_updated = (!wr_reg_n_in_ex) && (rs2 == rd_in_ex);
 
             if ((!rs1_updated) && (!rs2_updated)) begin
                 stall_ctrl = 1'b0;

--- a/src/top.v
+++ b/src/top.v
@@ -77,6 +77,11 @@ module top (
         .pc4(pc4_if),
         .next_pc(next_pc)
     );
+    // CHECK: ACKI_n will be 0 after data is read successfully from Imem
+    // assign IAD = current_pc
+    // if my hypothesis is correct then this will also work! (confirmed)
+    // then the problem is how do I interlock the pipeline when IAD != 0
+    // after read/write of Memory
     assign IAD = (ACKI_n == 1'b0) ? current_pc : 32'hx;
 
     //
@@ -356,6 +361,9 @@ module top (
     //
 
     wire [31:0] data_from_mem, data_to_mem;
+    // CHECK: ACKD_n will only be 0 after data is successfully
+    // read or write to Dmem
+    // => don't have to wait for ACKD_n to be 0 before write
     mem_stage mem_stage_inst(
         .data_mem_ready_n(ACKD_n),
         .data_from_mem(data_from_mem),

--- a/src/top.v
+++ b/src/top.v
@@ -362,7 +362,6 @@ module top (
         .opcode(opcode_from_ex),
         .funct3(funct3_from_ex),
         .b(b_from_ex),
-        .c(c_from_ex),
         .flush(flush_from_ex),
         .d(d_mem),
         .require_mem_access(MREQ),

--- a/src/top.v
+++ b/src/top.v
@@ -284,11 +284,10 @@ module top (
     // Data Forward Helper EX
     //
 
-    data_forward_helper data_forward_helper_ex(
+    data_forward_helper #(.IS_MEM_STAGE(0)) data_forward_helper_ex(
         .main_data(c_ex),
         .sub_data(pc4_from_id),
         .opcode(opcode_from_id),
-        .is_mem_stage(1'b0),
         .data_to_forward(data_forwarded_from_ex)
     );
 
@@ -379,11 +378,10 @@ module top (
     // Data Forward Helper MEM
     //
 
-    data_forward_helper data_forward_helper_mem(
+    data_forward_helper #(.IS_MEM_STAGE(1)) data_forward_helper_mem(
         .main_data(c_from_ex),
         .sub_data(d_mem),
         .opcode(opcode_from_ex),
-        .is_mem_stage(1'b1),
         .data_to_forward(data_forwarded_from_mem)
     );
 

--- a/test/test_mem_stage.v
+++ b/test/test_mem_stage.v
@@ -4,7 +4,7 @@ module test_mem_stage ();
     reg [6:0] opcode;
     reg [2:0] funct3;
     reg [6:0] opcode_from_ex;
-    reg [31:0] b, c;
+    reg [31:0] b;
     reg flush;
 
 
@@ -19,7 +19,6 @@ module test_mem_stage ();
         .opcode(opcode),
         .funct3(funct3),
         .b(b),
-        .c(c),
         .flush(flush),
         .d(d),
         .require_mem_access(require_mem_access),
@@ -39,36 +38,29 @@ module test_mem_stage ();
         assign data_from_mem = 32'ha0b1_c2d3; // better to have diff results for signed and unsigned
             // context: LB
             // size: 10
-            // d: ffff_ffb1
-        assign c = 32'h0000_0002;
+            // d: ffff_ffd3
         assign funct3 = 3'b000;
         #10
             // context: LH
             // size: 01
-            // d: ffff_a0b1
-        assign c = 32'h0000_0002;
+            // d: ffff_c2d3
         assign funct3 = 3'b001;
         #10
             // context: LW
             // size: 00
             // d: a0b1_c2d3
-        assign c = 32'h0000_0004;
         assign funct3 = 3'b010;
         #10
             // context: LBU
             // size: 10
             // d: 0000_00d3
-        assign c = 32'h0000_0000;
         assign funct3 = 3'b100;
         #10
             // context: LHU
             // size: 01
             // d: 0000_c2d3
-        assign c = 32'h0000_0000;
         assign funct3 = 3'b101;
         #10
-
-        assign c = 32'h0000_1234;
 
         // Store Instructions
         // require_mem_access: 1


### PR DESCRIPTION
- learnt about the basics of logic synthesis (minimize area first, then minimize speed)
- added a script to perform basic logic synthesis
- will come back later to perform more sophisticated synthesis

- add tcl script for logical synthesis
- add shellscripts to run logical synthesis
- Fix: Procedural-continuous assignments are not supported by synthesis. (VER-966) in mem_ctrl
- Fix: Procedural-continuous assignments are not supported by synthesis. (VER-966) in ld_converter
- Fix: Procedural-continuous assignments are not supported by synthesis. (VER-966) in stall_detector
- Fix: Cannot test variable 'rst_n' because it was not in the event expression or with wrong polarity. (ELAB-300)
- Fix:  id_ex_regs (if statement in always block need to be simple) '
- Fix typo of wb_stage.v
- Fix typo: mediium -> medium
- Fix: DEFAULT branch of CASE statement cannot be reached. (ELAB-311)
- Fix typo in id_ex_regs (input -> output)
- Fix unsigned to signed assignment occurs. (VER-318) in branch_alu
- all modules are included in top.v, so dont have to read them
- tried to fix: signed to unsigned assignment occurs. (VER-318) in alu.v
- use parameter for data_forward_helper instead of passing const signal of 0/1
- analyze and elaborate modules that has parameters
- remove c (not in used) from mem_stage
- add NOTEs about ACKI_n and ACKD_n
- basic Logic Synthesis Script
