### PR TITLE
Exception handling

### DIFF
--- a/doc/instruction_execution_table.md
+++ b/doc/instruction_execution_table.md
@@ -868,7 +868,17 @@
             <!-- instruction -->
             <td>ecall [?]</td>
             <!-- IF -->
+            <td>
+                IR ← mem[PC]
+                <br />
+                PC ← PC + 4
+            </td>
             <!-- ID -->
+            <td>
+                RaiseException
+                <br />
+                PC ← trap_vector_addr
+            </td>
             <!-- EX -->
             <td></td>
             <!-- MEM -->

--- a/script/simulate.py
+++ b/script/simulate.py
@@ -44,6 +44,7 @@ test_programs_paths = {
     "p2_part": "./test_pack/asm/p2_part/",
     "csr": "./test_pack/asm/csr/",
     "mret": "./test_pack/asm/mret/",
+    "trap": "./test_pack/exception/trap/",
 }
 
 def clean_test_ground():

--- a/src/csrs.v
+++ b/src/csrs.v
@@ -21,7 +21,8 @@ module csrs (
     input is_mret,
 
     // Outputs
-    output reg [31:0] csr_out
+    output reg [31:0] csr_out,
+    output reg [31:0] mtvec_out
 );
 
     wire wr_csr = !wr_csr_n;
@@ -167,6 +168,8 @@ module csrs (
     );
 
     always @(*) begin
+        // csr_out
+        //
         // NOTE: read mepc during mret instruction
         // - the csr_addr decoded from mepc = medeleg
         // - medeleg register doesn't exist in a M-only implementation
@@ -202,6 +205,10 @@ module csrs (
 
                 default: csr_out = 32'b0;
         endcase
+
+        // mtvec_out
+        //
+        mtvec_out = mtvec;
     end
 
 endmodule

--- a/src/csrs.v
+++ b/src/csrs.v
@@ -25,6 +25,7 @@ module csrs #(
     input is_mret,
 
     // Exception
+    input exception_raised,
     input [1:0] cause_in,
     input [31:0] epc_in,
     input [31:0] tval_in,
@@ -35,7 +36,6 @@ module csrs #(
 );
 
     wire wr_csr = !wr_csr_n;
-    wire exception_raised = cause_in != NOT_EXCEPTION;
 
     //
     // Priviledge Mode

--- a/src/csrs.v
+++ b/src/csrs.v
@@ -31,7 +31,7 @@ module csrs #(
 
     // Outputs
     output reg [31:0] csr_out,
-    output reg [31:0] mtvec_out
+    output reg [31:0] trap_vector_addr_out
 );
 
     wire wr_csr = !wr_csr_n;
@@ -87,10 +87,12 @@ module csrs #(
 
     wire [31:0] misa;
     wire [31:0] mtvec;
+    wire [31:0] trap_vector_addr;
     wire [31:0] mcounteren;
     m_trap_setup_regs m_trap_setup_regs_inst(
         .misa(misa),
         .mtvec(mtvec),
+        .trap_vector_addr(trap_vector_addr),
         .mcounteren(mcounteren)
     );
 
@@ -235,9 +237,9 @@ module csrs #(
                 default: csr_out = 32'b0;
         endcase
 
-        // mtvec_out
+        // trap_vector_addr_out
         //
-        mtvec_out = mtvec;
+        trap_vector_addr_out = trap_vector_addr;
     end
 
 endmodule

--- a/src/exception_ctrl_u.v
+++ b/src/exception_ctrl_u.v
@@ -1,0 +1,74 @@
+module exception_ctrl_u #(
+    parameter [1:0] NOT_EXCEPTION = 2'b00,
+    parameter [1:0] I_ADDR_MISALIGNMENT = 2'b01,
+    parameter [1:0] ILLEGAL_IR = 2'b10
+) (
+    // Instruction Address Misalignment
+    input i_addr_misaligned,
+    input [31:0] pc_of_i_addr_misaligned,
+
+    // Illegal Instruction
+    input illegal_ir,
+    input [31:0] ir_in_question,
+    input [31:0] pc_of_illegal_ir,
+
+    // Jump
+    input jump,
+
+    // Outputs
+    output [1:0] exception_cause,
+    output [31:0] exception_epc,
+    output [31:0] exception_tval
+);
+
+    //
+    // Main
+    //
+
+    assign exception_cause = cause_ctrl(i_addr_misaligned, illegal_ir, jump);
+    assign exception_epc = epc_ctrl(exception_cause, pc_of_i_addr_misaligned, pc_of_illegal_ir);
+    assign exception_tval = tval_ctrl(exception_cause, pc_of_i_addr_misaligned, ir_in_question);
+
+    //
+    // Function
+    //
+
+    function [1:0] cause_ctrl(input i_addr_misaligned, input illegal_ir, input jump);
+        begin
+            // Don't raise Exception when jump
+            // because this instruction will not be executed due to jump
+            if (jump) cause_ctrl = NOT_EXCEPTION;
+            else if (illegal_ir) cause_ctrl = ILLEGAL_IR;
+            else if (i_addr_misaligned) cause_ctrl = I_ADDR_MISALIGNMENT;
+            else cause_ctrl = NOT_EXCEPTION;
+        end
+    endfunction
+
+    function [31:0] epc_ctrl(input [1:0] cause, input [31:0] pc_of_i_addr_misaligned, input [31:0] pc_of_illegal_ir);
+        begin
+            case (cause)
+                ILLEGAL_IR: epc_ctrl = pc_of_illegal_ir;
+
+                I_ADDR_MISALIGNMENT: epc_ctrl = pc_of_i_addr_misaligned;
+                
+                // set to default pc
+                // include NOT_EXCEPTION
+                default: epc_ctrl = 32'h0001_0000;
+            endcase
+        end
+    endfunction
+
+    function [31:0] tval_ctrl(input [1:0] cause, input [31:0] pc_of_i_addr_misaligned, input [31:0] ir_in_question);
+        begin
+            case (cause)
+                ILLEGAL_IR: tval_ctrl = ir_in_question;
+
+                I_ADDR_MISALIGNMENT: tval_ctrl = pc_of_i_addr_misaligned;
+
+                // include NOT_EXCEPTION
+                default: tval_ctrl = 32'h0;
+            endcase
+        end
+    endfunction
+
+endmodule

--- a/src/exception_ctrl_u.v
+++ b/src/exception_ctrl_u.v
@@ -4,17 +4,15 @@ module exception_ctrl_u #(
     parameter [1:0] ILLEGAL_IR = 2'b10,
     parameter [1:0] ECALL = 2'b11
 ) (
-    // current pc
-    input [31:0] current_pc,
+    // Program Counter
+    input [31:0] pc_in_id,
 
     // Instruction Address Misalignment
     input i_addr_misaligned,
-    input [31:0] pc_of_i_addr_misaligned,
 
     // Illegal Instruction
     input illegal_ir,
-    input [31:0] ir_in_question,
-    input [31:0] pc_of_illegal_ir,
+    input [31:0] ir_in_id,
 
     // ECALL
     input is_ecall,
@@ -33,52 +31,66 @@ module exception_ctrl_u #(
     // Main
     //
 
-    wire is_first_instruction = (current_pc == 32'h0001_0000);
-
     assign exception_raised = exception_cause != NOT_EXCEPTION;
-    assign exception_cause = cause_ctrl(i_addr_misaligned, illegal_ir, is_ecall, is_first_instruction, jump);
-    assign exception_epc = epc_ctrl(exception_cause, pc_of_i_addr_misaligned, pc_of_illegal_ir);
-    assign exception_tval = tval_ctrl(exception_cause, pc_of_i_addr_misaligned, ir_in_question);
+    assign exception_cause = cause_ctrl(i_addr_misaligned, illegal_ir, is_ecall, jump);
+    assign exception_epc = epc_ctrl(exception_cause, pc_in_id);
+    assign exception_tval = tval_ctrl(exception_cause, pc_in_id, ir_in_id);
 
     //
     // Function
     //
 
-    function [1:0] cause_ctrl(input i_addr_misaligned, input illegal_ir, input is_ecall, input is_first_instruction, input jump);
+    function [1:0] cause_ctrl(input i_addr_misaligned, input illegal_ir, input is_ecall, input jump);
         begin
-            // Don't raise Exception when this is the first instruction in execution
             // Don't raise Exception when jump
             // because this instruction will not be executed due to jump
-            if (is_first_instruction || jump) cause_ctrl = NOT_EXCEPTION;
-            else if (illegal_ir) cause_ctrl = ILLEGAL_IR;
+            //
+            // NOTE:
+            // i_addr_misaligned signal is passed on from IF to ID stage.
+            // so if there's a situation like below:
+            //  F: i_addr_misaligned = 1,
+            //  D: branch ir (branch result not clear)
+            // passing on i_addr_misaligned signal to ID stage will produce the below situation:
+            //  D: i_addr_misaligned = 1,
+            //  E: branch ir (branch result known)
+            // with the knowledge of branch result, it's easier to decide whether to raise an exception or not
+            // even though the i_addr_misaligned is detected in IF stage
+            if (jump) cause_ctrl = NOT_EXCEPTION;
+            else if (jump) cause_ctrl = NOT_EXCEPTION;
+            // Priority of Exception:
+            // ILLEGAL_IR > I_ADDR_MISALIGNMENT > ECALL
+            //
+            // In general, checking ILLEGAL_IR before I_ADDR_MISALIGNED should be correct (based on the priority level).
+            // However, if both illegal_ir and i_addr_misaligned are active,
+            // it can be deduced that the illegal_ir is caused by i_addr_misaligned.
+            //
+            // illegal_ir   |   i_addr_misaligned   |   cause
+            // 0            |   0                   |   check ecall
+            // 0            |   1                   |   I_ADDR_MISALIGNMENT
+            // 1            |   0                   |   ILLEGAL_IR
+            // 1            |   1                   |   I_ADDR_MISALIGNMENT
+            //
+            // So we check for i_addr_misaligned first here.
             else if (i_addr_misaligned) cause_ctrl = I_ADDR_MISALIGNMENT;
+            else if (illegal_ir) cause_ctrl = ILLEGAL_IR;
             else if (is_ecall) cause_ctrl = ECALL;
             else cause_ctrl = NOT_EXCEPTION;
         end
     endfunction
 
-    function [31:0] epc_ctrl(input [1:0] cause, input [31:0] pc_of_i_addr_misaligned, input [31:0] pc_of_illegal_ir);
+    function [31:0] epc_ctrl(input [1:0] cause, input [31:0] pc);
         begin
-            case (cause)
-                ILLEGAL_IR: epc_ctrl = pc_of_illegal_ir;
-
-                I_ADDR_MISALIGNMENT: epc_ctrl = pc_of_i_addr_misaligned;
-
-                ECALL: epc_ctrl = pc_of_illegal_ir; // NOTE: need to rename this (pc_of_illegal_ir is from ID stage)
-                
-                // set to default pc
-                // include NOT_EXCEPTION
-                default: epc_ctrl = 32'h0001_0000;
-            endcase
+            if (cause == NOT_EXCEPTION) epc_ctrl = 32'h0001_0000;
+            else epc_ctrl = pc;
         end
     endfunction
 
-    function [31:0] tval_ctrl(input [1:0] cause, input [31:0] pc_of_i_addr_misaligned, input [31:0] ir_in_question);
+    function [31:0] tval_ctrl(input [1:0] cause, input [31:0] pc, input [31:0] ir);
         begin
             case (cause)
-                ILLEGAL_IR: tval_ctrl = ir_in_question;
+                ILLEGAL_IR: tval_ctrl = ir;
 
-                I_ADDR_MISALIGNMENT: tval_ctrl = pc_of_i_addr_misaligned;
+                I_ADDR_MISALIGNMENT: tval_ctrl = pc;
 
                 // include NOT_EXCEPTION, ECALL
                 default: tval_ctrl = 32'h0;

--- a/src/exception_ctrl_u.v
+++ b/src/exception_ctrl_u.v
@@ -19,6 +19,7 @@ module exception_ctrl_u #(
     input jump,
 
     // Outputs
+    output exception_raised,
     output [1:0] exception_cause,
     output [31:0] exception_epc,
     output [31:0] exception_tval
@@ -30,6 +31,7 @@ module exception_ctrl_u #(
 
     wire is_first_instruction = (current_pc == 32'h0001_0000);
 
+    assign exception_raised = exception_cause != NOT_EXCEPTION;
     assign exception_cause = cause_ctrl(i_addr_misaligned, illegal_ir, is_first_instruction, jump);
     assign exception_epc = epc_ctrl(exception_cause, pc_of_i_addr_misaligned, pc_of_illegal_ir);
     assign exception_tval = tval_ctrl(exception_cause, pc_of_i_addr_misaligned, ir_in_question);

--- a/src/id_ex_regs.v
+++ b/src/id_ex_regs.v
@@ -86,23 +86,29 @@ module id_ex_regs (
             // as a way to prevent double detection of
             // pipeline stall.
             //
+            // pipeline registers that are used for stall detection:
+            // - rs1, rs2, opcode_in_id
+            // - wr_reg_n_in_ex, rd_in_ex, opcode_in_ex
+            // only have to set wr_reg_n and wr_csr_n to 1 (inactive)
+            // to prevent double detection.
+            //
             // since interlock behaves just like stall
             // interlock has the same behaviour as reset.
-            pc <= 32'bx;
-            pc4 <= 32'bx;
-            data1 <= 32'bx;
-            data2 <= 32'bx;
-            funct7 <= 7'bx;
-            funct3 <= 3'bx;
-            rs2 <= 5'bx;
-            rd <= 5'bx;
-            csr_addr <= 12'bx;
-            opcode <= 7'bx;
-            imm <= 32'bx;
-            z_ <= 32'bx;
-            wr_reg_n <= 1'b1;   // default not to write
-            wr_csr_n <= 1'b1;   // default not to write
-            flush <= 1'b0;      // default not to flush
+            pc <= pc;
+            pc4 <= pc4;
+            data1 <= data1;
+            data2 <= data2;
+            funct7 <= funct7;
+            funct3 <= funct3;
+            rs2 <= rs2;
+            rd <= rd;
+            csr_addr <= csr_addr;
+            opcode <= opcode;
+            imm <= imm;
+            z_ <= z_;
+            wr_reg_n <= 1'b1;   // not write to prevent double detection
+            wr_csr_n <= 1'b1;   // not write to prevent double detection
+            flush <= flush;
         end else begin
             pc <= pc_in;
             pc4 <= pc4_in;

--- a/src/id_stage.v
+++ b/src/id_stage.v
@@ -31,6 +31,7 @@ module id_stage
     output wr_reg_n,    // 0: write, 1: don't write
     output wr_csr_n,    // 0: write, 1: don't write
     output is_mret,     // 0: not mret, 1: mret
+    output is_ecall,    // 0: not ecall, 1: ecall
     output illegal_ir   // 0: legal, 1: illegal
 );
 
@@ -49,6 +50,7 @@ module id_stage
 
     localparam [11:0] MEPC_ADDR = 12'h341;
     localparam [31:0] MRET_IR = 32'b0011000_00010_00000_000_00000_1110011;
+    localparam [31:0] ECALL_IR = 32'b000000000000_00000_000_00000_1110011;
 
     //
     // Main
@@ -92,6 +94,7 @@ module id_stage
     assign wr_csr_n = wr_csr_n_ctrl(opcode, funct3, rs1, illegal_ir);
 
     assign is_mret = (ir == MRET_IR);
+    assign is_ecall = (ir == ECALL_IR);
 
     assign illegal_ir = illegal_ir_check(opcode, funct3, funct7, is_mret);
 
@@ -237,8 +240,8 @@ module id_stage
 
                 SYSTEM_OP: begin
                     // MRET
-                    // illegal if instruction with funct3 of 000 is not mret
-                    if (funct3 == 3'b000) illegal_ir_check = !is_mret;
+                    // illegal if instruction with funct3 of 000 is not (mret or ecall)
+                    if (funct3 == 3'b000) illegal_ir_check = !(is_mret || is_ecall);
                     // CSRs instructions does not have funct3 of { 000, 100 }
                     else illegal_ir_check = (funct3 == 3'b100);
                 end

--- a/src/if_ctrl.v
+++ b/src/if_ctrl.v
@@ -1,12 +1,37 @@
-module if_ctrl (
+module if_ctrl #(
+    parameter [1:0] NOT_EXCEPTION = 2'b00
+) (
     input [31:0] pc4,
     input [31:0] c,
     input jump,
+    input [1:0] exception_cause,
+    input [31:0] exception_handling_addr,
+
     output [31:0] next_pc
 );
     
     //
     // Main
     //
-    assign next_pc = (jump == 1'b1) ? c : pc4;
+
+    assign next_pc = next_pc_ctrl(pc4, c, jump, exception_cause, exception_handling_addr);
+
+    //
+    // Function
+    //
+
+    function [31:0] next_pc_ctrl(
+        input [31:0] pc4,
+        input [31:0] c,
+        input jump,
+        input [1:0] exception_cause,
+        input [31:0] exception_handling_addr
+    );
+        begin
+           if (jump) next_pc_ctrl = c;
+           else if (exception_cause != NOT_EXCEPTION) next_pc_ctrl = exception_handling_addr;
+           else next_pc_ctrl = pc4;
+        end
+    endfunction
+
 endmodule

--- a/src/if_ctrl.v
+++ b/src/if_ctrl.v
@@ -1,10 +1,8 @@
-module if_ctrl #(
-    parameter [1:0] NOT_EXCEPTION = 2'b00
-) (
+module if_ctrl (
     input [31:0] pc4,
     input [31:0] c,
     input jump,
-    input [1:0] exception_cause,
+    input exception_raised,
     input [31:0] exception_handling_addr,
 
     output [31:0] next_pc
@@ -14,7 +12,7 @@ module if_ctrl #(
     // Main
     //
 
-    assign next_pc = next_pc_ctrl(pc4, c, jump, exception_cause, exception_handling_addr);
+    assign next_pc = next_pc_ctrl(pc4, c, jump, exception_raised, exception_handling_addr);
 
     //
     // Function
@@ -24,12 +22,12 @@ module if_ctrl #(
         input [31:0] pc4,
         input [31:0] c,
         input jump,
-        input [1:0] exception_cause,
+        input exception_raised,
         input [31:0] exception_handling_addr
     );
         begin
            if (jump) next_pc_ctrl = c;
-           else if (exception_cause != NOT_EXCEPTION) next_pc_ctrl = exception_handling_addr;
+           else if (exception_raised) next_pc_ctrl = exception_handling_addr;
            else next_pc_ctrl = pc4;
         end
     endfunction

--- a/src/if_id_regs.v
+++ b/src/if_id_regs.v
@@ -14,13 +14,19 @@ module if_id_regs (
     output [31:0] ir_out,
 
     input flush_in,
-    output flush_out
+    output flush_out,
+
+    input i_addr_misaligned_in,
+    output i_addr_misaligned_out
 );
 
     reg [31:0] pc;
     reg [31:0] pc4;
     reg [31:0] ir;
     reg flush;
+    reg i_addr_misaligned;
+
+    localparam [31:0] NOP_IR = { 12'b0, 5'b0, 3'b0, 5'b0, 7'b0010011 };
 
     always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
@@ -29,18 +35,21 @@ module if_id_regs (
             pc4 <= 32'bx;
             ir <= 32'bx;
             flush <= 1'b0;  // default not to flush
+            i_addr_misaligned <= 1'b0;
         end else if (stall || interlock) begin
             // holds the same value when stall or interlock
             pc <= pc;
             pc4 <= pc4;
             ir <= ir;
             flush <= flush;
+            i_addr_misaligned <= i_addr_misaligned;
         end else begin
             // update value
             pc <= pc_in;
             pc4 <= pc4_in;
             ir <= ir_in;
             flush <= flush_in;
+            i_addr_misaligned <= i_addr_misaligned_in;
         end
     end
 
@@ -48,5 +57,6 @@ module if_id_regs (
     assign pc4_out = pc4;
     assign ir_out = ir;
     assign flush_out = flush;
+    assign i_addr_misaligned_out = i_addr_misaligned;
     
 endmodule

--- a/src/if_id_regs.v
+++ b/src/if_id_regs.v
@@ -33,7 +33,7 @@ module if_id_regs (
             // reset
             pc <= 32'bx;
             pc4 <= 32'bx;
-            ir <= 32'bx;
+            ir <= NOP_IR;   // NOP instruction is the same as not performing anything
             flush <= 1'b0;  // default not to flush
             i_addr_misaligned <= 1'b0;
         end else if (stall || interlock) begin

--- a/src/if_stage.v
+++ b/src/if_stage.v
@@ -6,6 +6,9 @@ module if_stage (
     input [31:0] c,
     input jump,
 
+    input [1:0] exception_cause,
+    input [31:0] exception_handling_addr,
+
     output [31:0] pc4,
     output [31:0] next_pc,
     output i_addr_misaligned
@@ -20,6 +23,8 @@ module if_stage (
         .pc4(pc4),
         .c(c),
         .jump(jump),
+        .exception_cause(exception_cause),
+        .exception_handling_addr(exception_handling_addr),
         .next_pc(next_pc)
     );
 

--- a/src/if_stage.v
+++ b/src/if_stage.v
@@ -5,8 +5,10 @@ module if_stage (
     input [31:0] current_pc,
     input [31:0] c,
     input jump,
+
     output [31:0] pc4,
-    output [31:0] next_pc
+    output [31:0] next_pc,
+    output i_addr_misaligned
 );
 
     pc_adder if_pc_adder(
@@ -20,5 +22,12 @@ module if_stage (
         .jump(jump),
         .next_pc(next_pc)
     );
+
+    // Detection for Instruction Address Misalignment
+    //
+    // Instructions are stored in Imem with address of mulitple of 4.
+    // Allowed value for lower 2 bits of instruction address are { 0, 4, 8, c }
+    // which lower 2 bits are 00 in binary.
+    assign i_addr_misaligned = current_pc[1:0] != 2'b00;
     
 endmodule

--- a/src/if_stage.v
+++ b/src/if_stage.v
@@ -6,7 +6,7 @@ module if_stage (
     input [31:0] c,
     input jump,
 
-    input [1:0] exception_cause,
+    input exception_raised,
     input [31:0] exception_handling_addr,
 
     output [31:0] pc4,
@@ -23,7 +23,7 @@ module if_stage (
         .pc4(pc4),
         .c(c),
         .jump(jump),
-        .exception_cause(exception_cause),
+        .exception_raised(exception_raised),
         .exception_handling_addr(exception_handling_addr),
         .next_pc(next_pc)
     );

--- a/src/m_trap_setup_regs.v
+++ b/src/m_trap_setup_regs.v
@@ -1,6 +1,7 @@
 module m_trap_setup_regs (
     output [31:0] misa,
     output [31:0] mtvec,
+    output [31:0] trap_vector_addr,
     output [31:0] mcounteren
 );
 
@@ -21,8 +22,7 @@ module m_trap_setup_regs (
     // might need to allow setup of mtvec value on boot ...
 
     // Base Address
-    // TODO: need to confirm the Base Address value
-    localparam [31:0] trap_vector_base_addr = 32'h4;    // 0000_0004
+    localparam [31:0] trap_vector_base_addr = 32'h0;    // 0000_0000
     // Trap Vector Mode
     // 0    : Direct    : pc = trap_vector_base_addr
     // 1    : Vectored  : pc = trap_vector_base_addr + 4 * cause
@@ -30,6 +30,7 @@ module m_trap_setup_regs (
     localparam [1:0] trap_vector_mode = 2'b00;
     // mtvec: { BASE, MODE }
     assign mtvec = { trap_vector_base_addr[31:2], trap_vector_mode };
+    assign trap_vector_addr = trap_vector_base_addr;
 
     // Machine Counter-Enable Register
     // don't allow for the moment

--- a/src/mstatus_reg.v
+++ b/src/mstatus_reg.v
@@ -3,6 +3,7 @@ module mstatus_reg (
     input rst_n,
 
     input is_mret,
+    input exception_raised,
 
     input [31:0] mstatus_in,
     input wr_mstatus,
@@ -58,27 +59,26 @@ module mstatus_reg (
             // on reset,
             // priviledge mode is set to M
             // MIE is reset to 0
-            current_mode <= machine_mode;
+            // User-mode not supported
+            { current_mode, mpp, spp } <= { machine_mode, machine_mode, 1'b0 };
             { mie, sie, uie } <= 3'b100;
             { mpie, spie, upie } <= 3'b000;
-            // User-mode not supported
-            mpp <= machine_mode;
-            spp <= 1'b0;
+        end else if (exception_raised) begin
+            { current_mode, mpp } <= { machine_mode, current_mode };
+            { mpie, mie } <= { mie, 1'b0 };
         end else if (is_mret) begin
             { mie, mpie } <= { mpie, 1'b1 };
         end else if (wr_mstatus) begin
             // TODO: not sure how to update current_mode
             { mie, sie, uie } <= { mstatus_in[3], mstatus_in[1:0] };
             { mpie, spie, upie } <= { mstatus_in[7], mstatus_in[5:4] };
-            mpp <= mstatus_in[12:11];
-            spp <= mstatus_in[8];
+            { mpp, spp } <= { mstatus_in[12:11], mstatus_in[8] };
         end else begin
             // No interruption
             current_mode <= current_mode;
             { mie, sie, uie } <= { mie, sie, uie };
             { mpie, spie, upie } <= { mpie, spie, upie };
-            mpp <= mpp;
-            spp <= spp;
+            { mpp, spp } <= { mpp, spp };
         end
     end
 

--- a/src/top.v
+++ b/src/top.v
@@ -157,6 +157,7 @@ module top (
 
     // Exception Handling
     wire i_addr_misaligned;
+    wire illegal_ir;
 
     //
     // Modules Instantiation
@@ -211,7 +212,8 @@ module top (
         .imm(imm_id),
         .wr_reg_n(wr_reg_n_id_stage),
         .wr_csr_n(wr_csr_n_id_stage),
-        .is_mret(is_mret_id)
+        .is_mret(is_mret_id),
+        .illegal_ir(illegal_ir)
     );
 
     id_data_picker id_data_picker_inst(

--- a/src/top.v
+++ b/src/top.v
@@ -158,7 +158,8 @@ module top (
     wire interlock;
 
     // Exception Handling
-    wire i_addr_misaligned;
+    wire i_addr_misaligned_if;
+    wire i_addr_misaligned_from_if;
     wire illegal_ir;
     wire exception_raised;
     wire [1:0] exception_cause;
@@ -188,7 +189,7 @@ module top (
         .exception_handling_addr(trap_vector_addr),
         .pc4(pc4_if),
         .next_pc(next_pc),
-        .i_addr_misaligned(i_addr_misaligned)
+        .i_addr_misaligned(i_addr_misaligned_if)
     );
     assign IAD = current_pc;
 
@@ -205,7 +206,9 @@ module top (
         .ir_in(IDT),
         .ir_out(ir_from_if),
         .flush_in(flush),
-        .flush_out(flush_from_if)
+        .flush_out(flush_from_if),
+        .i_addr_misaligned_in(i_addr_misaligned_if),
+        .i_addr_misaligned_out(i_addr_misaligned_from_if)
     );
 
     // ID
@@ -516,12 +519,10 @@ module top (
 
     // Exception Handling
     exception_ctrl_u exception_ctrl_u_inst(
-        .current_pc(current_pc),
-        .i_addr_misaligned(i_addr_misaligned),
-        .pc_of_i_addr_misaligned(current_pc),
+        .pc_in_id(pc_from_if),
+        .i_addr_misaligned(i_addr_misaligned_from_if),
         .illegal_ir(illegal_ir),
-        .ir_in_question(ir_from_if),
-        .pc_of_illegal_ir(pc_from_if),
+        .ir_in_id(ir_from_if),
         .is_ecall(is_ecall_id),
         .jump(jump_ex),
         .exception_raised(exception_raised),

--- a/src/top.v
+++ b/src/top.v
@@ -159,6 +159,7 @@ module top (
     // Exception Handling
     wire i_addr_misaligned;
     wire illegal_ir;
+    wire exception_raised;
     wire [1:0] exception_cause;
     wire [31:0] exception_epc;
     wire [31:0] exception_tval;
@@ -182,7 +183,7 @@ module top (
         .current_pc(current_pc),
         .c(c_ex),
         .jump(jump_ex),
-        .exception_cause(exception_cause),
+        .exception_raised(exception_raised),
         .exception_handling_addr(trap_vector_addr),
         .pc4(pc4_if),
         .next_pc(next_pc),
@@ -433,6 +434,7 @@ module top (
         .csr_data_in(csr_data_in),
         .wr_csr_n(wr_csr_n_from_mem),
         .is_mret(is_mret_id),
+        .exception_raised(exception_raised),
         .cause_in(exception_cause),
         .epc_in(exception_epc),
         .tval_in(exception_tval),
@@ -519,6 +521,7 @@ module top (
         .ir_in_question(ir_from_if),
         .pc_of_illegal_ir(pc_from_if),
         .jump(jump_ex),
+        .exception_raised(exception_raised),
         .exception_cause(exception_cause),
         .exception_epc(exception_epc),
         .exception_tval(exception_tval)

--- a/src/top.v
+++ b/src/top.v
@@ -155,6 +155,9 @@ module top (
     // Pipeline Interlock
     wire interlock;
 
+    // Exception Handling
+    wire i_addr_misaligned;
+
     //
     // Modules Instantiation
     //
@@ -174,7 +177,8 @@ module top (
         .c(c_ex),
         .jump(jump_ex),
         .pc4(pc4_if),
-        .next_pc(next_pc)
+        .next_pc(next_pc),
+        .i_addr_misaligned(i_addr_misaligned)
     );
     assign IAD = current_pc;
 

--- a/src/top.v
+++ b/src/top.v
@@ -162,6 +162,7 @@ module top (
     wire [1:0] exception_cause;
     wire [31:0] exception_epc;
     wire [31:0] exception_tval;
+    wire [31:0] mtvec;
 
     //
     // Modules Instantiation
@@ -430,7 +431,8 @@ module top (
         .csr_data_in(csr_data_in),
         .wr_csr_n(wr_csr_n_from_mem),
         .is_mret(is_mret_id),
-        .csr_out(z_csrs)
+        .csr_out(z_csrs),
+        .mtvec_out(mtvec)
     );
 
     // Data Forwarding

--- a/src/top.v
+++ b/src/top.v
@@ -510,6 +510,7 @@ module top (
 
     // Exception Handling
     exception_ctrl_u exception_ctrl_u_inst(
+        .current_pc(current_pc),
         .i_addr_misaligned(i_addr_misaligned),
         .pc_of_i_addr_misaligned(current_pc),
         .illegal_ir(illegal_ir),

--- a/src/top.v
+++ b/src/top.v
@@ -431,6 +431,9 @@ module top (
         .csr_data_in(csr_data_in),
         .wr_csr_n(wr_csr_n_from_mem),
         .is_mret(is_mret_id),
+        .cause_in(exception_cause),
+        .epc_in(exception_epc),
+        .tval_in(exception_tval),
         .csr_out(z_csrs),
         .mtvec_out(mtvec)
     );

--- a/src/top.v
+++ b/src/top.v
@@ -77,6 +77,7 @@ module top (
     wire wr_reg_n_id;
     wire wr_csr_n_id;
     wire is_mret_id;
+    wire is_ecall_id;
 
     // ID-EX
     wire [31:0] pc_from_id;
@@ -221,6 +222,7 @@ module top (
         .wr_reg_n(wr_reg_n_id_stage),
         .wr_csr_n(wr_csr_n_id_stage),
         .is_mret(is_mret_id),
+        .is_ecall(is_ecall_id),
         .illegal_ir(illegal_ir)
     );
 
@@ -520,6 +522,7 @@ module top (
         .illegal_ir(illegal_ir),
         .ir_in_question(ir_from_if),
         .pc_of_illegal_ir(pc_from_if),
+        .is_ecall(is_ecall_id),
         .jump(jump_ex),
         .exception_raised(exception_raised),
         .exception_cause(exception_cause),

--- a/src/top.v
+++ b/src/top.v
@@ -182,6 +182,8 @@ module top (
         .current_pc(current_pc),
         .c(c_ex),
         .jump(jump_ex),
+        .exception_cause(exception_cause),
+        .exception_handling_addr(mtvec),
         .pc4(pc4_if),
         .next_pc(next_pc),
         .i_addr_misaligned(i_addr_misaligned)

--- a/src/top.v
+++ b/src/top.v
@@ -6,6 +6,7 @@
 `include "ex_jump_picker.v"
 `include "ex_mem_regs.v"
 `include "ex_stage.v"
+`include "exception_ctrl_u.v"
 `include "flush_u.v"
 `include "id_data_picker.v"
 `include "id_ex_regs.v"
@@ -158,6 +159,9 @@ module top (
     // Exception Handling
     wire i_addr_misaligned;
     wire illegal_ir;
+    wire [1:0] exception_cause;
+    wire [31:0] exception_epc;
+    wire [31:0] exception_tval;
 
     //
     // Modules Instantiation
@@ -497,6 +501,19 @@ module top (
         .dmem_ack_n(ACKD_n),
         .opcode(opcode_from_ex),
         .interlock(interlock)
+    );
+
+    // Exception Handling
+    exception_ctrl_u exception_ctrl_u_inst(
+        .i_addr_misaligned(i_addr_misaligned),
+        .pc_of_i_addr_misaligned(current_pc),
+        .illegal_ir(illegal_ir),
+        .ir_in_question(ir_from_if),
+        .pc_of_illegal_ir(pc_from_if),
+        .jump(jump_ex),
+        .exception_cause(exception_cause),
+        .exception_epc(exception_epc),
+        .exception_tval(exception_tval)
     );
 
 endmodule

--- a/src/top.v
+++ b/src/top.v
@@ -162,7 +162,7 @@ module top (
     wire [1:0] exception_cause;
     wire [31:0] exception_epc;
     wire [31:0] exception_tval;
-    wire [31:0] mtvec;
+    wire [31:0] trap_vector_addr;
 
     //
     // Modules Instantiation
@@ -183,7 +183,7 @@ module top (
         .c(c_ex),
         .jump(jump_ex),
         .exception_cause(exception_cause),
-        .exception_handling_addr(mtvec),
+        .exception_handling_addr(trap_vector_addr),
         .pc4(pc4_if),
         .next_pc(next_pc),
         .i_addr_misaligned(i_addr_misaligned)
@@ -437,7 +437,7 @@ module top (
         .epc_in(exception_epc),
         .tval_in(exception_tval),
         .csr_out(z_csrs),
-        .mtvec_out(mtvec)
+        .trap_vector_addr_out(trap_vector_addr)
     );
 
     // Data Forwarding

--- a/test/test_exception_ctrl_u.v
+++ b/test/test_exception_ctrl_u.v
@@ -1,0 +1,86 @@
+module test_exception_ctrl_u ();
+
+    reg i_addr_misaligned, illegal_ir, jump;
+    reg [31:0] pc_of_i_addr_misaligned, pc_of_illegal_ir, ir_in_question;
+    
+    wire [1:0] exception_cause;
+    wire [31:0] exception_epc, exception_tval;
+
+    exception_ctrl_u subject(
+        .i_addr_misaligned(i_addr_misaligned),
+        .pc_of_i_addr_misaligned(pc_of_i_addr_misaligned),
+        .illegal_ir(illegal_ir),
+        .ir_in_question(ir_in_question),
+        .pc_of_illegal_ir(pc_of_illegal_ir),
+        .jump(jump),
+        .exception_cause(exception_cause),
+        .exception_epc(exception_epc),
+        .exception_tval(exception_tval)
+    );
+
+    initial begin
+        pc_of_i_addr_misaligned = 32'd6;
+        pc_of_illegal_ir = 32'd8;
+        ir_in_question = 32'hf;
+
+        { jump, illegal_ir, i_addr_misaligned } = 3'b000;
+        // cause: 00
+        // epc: 0001_0000
+        // tval: 0000_0000
+        #10
+
+        { jump, illegal_ir, i_addr_misaligned } = 3'b001;
+        // cause: 01
+        // epc: 0000_0006
+        // tval: 0000_0006
+        #10
+
+        { jump, illegal_ir, i_addr_misaligned } = 3'b010;
+        // cause: 10
+        // epc: 0000_0008
+        // tval: 0000_000f
+        #10
+
+        { jump, illegal_ir, i_addr_misaligned } = 3'b011;
+        // cause: 10
+        // epc: 0000_0008
+        // tval: 0000_000f
+        #10
+        
+        { jump, illegal_ir, i_addr_misaligned } = 3'b100;
+        // cause: 00
+        // epc: 0001_0000
+        // tval: 0000_0000
+        #10
+
+        { jump, illegal_ir, i_addr_misaligned } = 3'b101;
+        // cause: 00
+        // epc: 0001_0000
+        // tval: 0000_0000
+        #10
+
+        { jump, illegal_ir, i_addr_misaligned } = 3'b110;
+        // cause: 00
+        // epc: 0001_0000
+        // tval: 0000_0000
+        #10
+
+        { jump, illegal_ir, i_addr_misaligned } = 3'b111;
+        // cause: 00
+        // epc: 0001_0000
+        // tval: 0000_0000
+        #10
+
+        $finish;
+    end
+
+    initial begin
+        $monitor(
+            "t: %d, cause: %b, epc: %h, tval: %h",
+            $time,
+            exception_cause,
+            exception_epc,
+            exception_tval
+        );
+    end
+endmodule

--- a/test/test_id_stage.v
+++ b/test/test_id_stage.v
@@ -12,6 +12,7 @@ module test_id_stage ();
     wire [31:0] imm;
     wire wr_reg_n;
     wire wr_csr_n;
+    wire illegal_ir;
 
     id_stage subject(
         .ir(ir),
@@ -24,7 +25,8 @@ module test_id_stage ();
         .csr_addr(csr_addr),
         .imm(imm),
         .wr_reg_n(wr_reg_n),
-        .wr_csr_n(wr_csr_n)
+        .wr_csr_n(wr_csr_n),
+        .illegal_ir(illegal_ir)
     );
 
     initial begin
@@ -34,6 +36,7 @@ module test_id_stage ();
         // imm: 0
         // rd: 3
         // wr_reg_n: 0
+        // illegal_ir: 0
         #5
 
         // AUIPC
@@ -42,6 +45,7 @@ module test_id_stage ();
         // imm: 0
         // rd: 3
         // wr_reg_n: 0
+        // illegal_ir: 0
         #5
 
         // JAL
@@ -50,6 +54,7 @@ module test_id_stage ();
         // imm: 2
         // rd: 3
         // wr_reg_n: 0
+        // illegal_ir: 0
         #5
 
         // JAL with rd: 0
@@ -58,6 +63,7 @@ module test_id_stage ();
         // imm: 2
         // rd: 0
         // wr_reg_n: 1
+        // illegal_ir: 0
         #5
 
         // JALR
@@ -68,6 +74,17 @@ module test_id_stage ();
         // rd: 3
         // funct3: 000
         // wr_reg_n: 0
+        // illegal_ir: 0
+        #5
+        // JALR (illegal)
+        assign ir = 32'b0000_0000_0010_00001_001_00011_1100111;
+        // opcode: 1100111
+        // imm: 2
+        // rs1: 1
+        // rd: 3
+        // funct3: 001
+        // wr_reg_n: 0
+        // illegal_ir: 1
         #5
 
         // Branch: BEQ
@@ -78,6 +95,27 @@ module test_id_stage ();
         // rs2: 2
         // funct3: 000
         // wr_reg_n: 1
+        // illegal_ir: 0
+        #5
+        // Branch: Illegal
+        assign ir = 32'b0_000000_00010_00001_010_0001_0_1100011;
+        // opcode: 1100011
+        // imm: 2
+        // rs1: 1
+        // rs2: 2
+        // funct3: 010
+        // wr_reg_n: 1
+        // illegal_ir: 1
+        #5
+        // Branch: Illegal
+        assign ir = 32'b0_000000_00010_00001_011_0001_0_1100011;
+        // opcode: 1100011
+        // imm: 2
+        // rs1: 1
+        // rs2: 2
+        // funct3: 011
+        // wr_reg_n: 1
+        // illegal_ir: 1
         #5
 
         // Load: LB
@@ -88,6 +126,37 @@ module test_id_stage ();
         // rd: 3
         // funct3: 000
         // wr_reg_n: 0
+        // illegal_ir: 0
+        #5
+        // Load: Illegal
+        assign ir = 32'b0000_0000_0010_00001_011_00011_0000011;
+        // opcode: 0000011
+        // imm: 2
+        // rs1: 1
+        // rd: 3
+        // funct3: 000
+        // wr_reg_n: 0
+        // illegal_ir: 1
+        #5
+        // Load: Illegal
+        assign ir = 32'b0000_0000_0010_00001_110_00011_0000011;
+        // opcode: 0000011
+        // imm: 2
+        // rs1: 1
+        // rd: 3
+        // funct3: 000
+        // wr_reg_n: 0
+        // illegal_ir: 1
+        #5
+        // Load: Illegal
+        assign ir = 32'b0000_0000_0010_00001_111_00011_0000011;
+        // opcode: 0000011
+        // imm: 2
+        // rs1: 1
+        // rd: 3
+        // funct3: 000
+        // wr_reg_n: 0
+        // illegal_ir: 1
         #5
 
         // Store: SB
@@ -98,6 +167,57 @@ module test_id_stage ();
         // rs2: 2
         // funct3: 000
         // wr_reg_n: 1
+        // illegal_ir: 0
+        #5
+        // Store: Illegal
+        assign ir = 32'b0000000_00010_00001_011_00010_0100011;
+        // opcode: 0100011
+        // imm: 2
+        // rs1: 1
+        // rs2: 2
+        // funct3: 000
+        // wr_reg_n: 1
+        // illegal_ir: 1
+        #5
+        // Store: SB
+        assign ir = 32'b0000000_00010_00001_100_00010_0100011;
+        // opcode: 0100011
+        // imm: 2
+        // rs1: 1
+        // rs2: 2
+        // funct3: 000
+        // wr_reg_n: 1
+        // illegal_ir: 1
+        #5
+        // Store: SB
+        assign ir = 32'b0000000_00010_00001_101_00010_0100011;
+        // opcode: 0100011
+        // imm: 2
+        // rs1: 1
+        // rs2: 2
+        // funct3: 000
+        // wr_reg_n: 1
+        // illegal_ir: 1
+        #5
+        // Store: SB
+        assign ir = 32'b0000000_00010_00001_110_00010_0100011;
+        // opcode: 0100011
+        // imm: 2
+        // rs1: 1
+        // rs2: 2
+        // funct3: 000
+        // wr_reg_n: 1
+        // illegal_ir: 1
+        #5
+        // Store: SB
+        assign ir = 32'b0000000_00010_00001_111_00010_0100011;
+        // opcode: 0100011
+        // imm: 2
+        // rs1: 1
+        // rs2: 2
+        // funct3: 000
+        // wr_reg_n: 1
+        // illegal_ir: 1
         #5
 
         // I: ADDI r3, r1, 12'h801
@@ -124,12 +244,20 @@ module test_id_stage ();
         // ecall
         assign ir = 32'b000000000000_00000_000_00000_1110011;
         // wr_csr_n: 1
+        // illegal_ir: 1
         #5
 
         // CSR
         assign ir = 32'b001100000000_00001_001_00010_1110011;
         // csr_addr = h300
         // wr_csr_n: 0
+        // illegal_ir: 0
+        #5
+        // CSR: Illegal
+        assign ir = 32'b001100000000_00001_100_00010_1110011;
+        // csr_addr = h300
+        // wr_csr_n: 0
+        // illegal_ir: 1
         #5
 
         $finish;
@@ -137,7 +265,7 @@ module test_id_stage ();
 
     initial begin
         $monitor(
-            "time: %3d,\nrs1: %d,\nrs2: %d,\nrd: %d,\nopcode: %b,\nfunct3: %b,\nfunct7: %b,\ncsr_addr: %h,\nimm: %h,\nwr_reg_n: %b,\nwr_csr_n: %b\n",
+            "time: %3d,\nrs1: %d,\nrs2: %d,\nrd: %d,\nopcode: %b,\nfunct3: %b,\nfunct7: %b,\ncsr_addr: %h,\nimm: %h,\nwr_reg_n: %b,\nwr_csr_n: %b\nillegal_ir: %b\n",
             $time,
             rs1,
             rs2,
@@ -148,7 +276,8 @@ module test_id_stage ();
             csr_addr,
             imm,
             wr_reg_n,
-            wr_csr_n
+            wr_csr_n,
+            illegal_ir
         );
     end
 endmodule

--- a/test/test_if_stage.v
+++ b/test/test_if_stage.v
@@ -5,13 +5,15 @@ module test_if_stage ();
 
     wire [31:0] next_pc;
     wire [31:0] pc4;
+    wire i_addr_misaligned;
 
     if_stage subject(
         .current_pc(current_pc),
         .c(c),
         .jump(jump),
         .pc4(pc4),
-        .next_pc(next_pc)
+        .next_pc(next_pc),
+        .i_addr_misaligned(i_addr_misaligned)
     );
 
     initial begin
@@ -30,6 +32,68 @@ module test_if_stage ();
         assign jump = 1'b1;
         #10
 
+        // no jump
+        // address misaligned
+        assign jump = 1'b0;
+        // i_addr_misaligned = 0
+        assign current_pc = 32'h0;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'h1;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'h2;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'h3;
+        #10
+        // i_addr_misaligned = 0
+        assign current_pc = 32'h4;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'h5;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'h6;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'h7;
+        #10
+        // i_addr_misaligned = 0
+        assign current_pc = 32'h8;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'h9;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'ha;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'hb;
+        #10
+        // i_addr_misaligned = 0
+        assign current_pc = 32'hc;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'hd;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'he;
+        #10
+        // i_addr_misaligned = 1
+        assign current_pc = 32'hf;
+        #10
+
         $finish;
+    end
+
+    initial begin
+        $monitor(
+            "t: %d, pc4: %h, next_pc: %h, i_addr_misaligned: %b",
+            $time,
+            pc4,
+            next_pc,
+            i_addr_misaligned
+        );
     end
 endmodule

--- a/test_pack/exception/trap/makefile
+++ b/test_pack/exception/trap/makefile
@@ -1,0 +1,2 @@
+TARGET = test
+include /opt/riscv/default_s_makefile

--- a/test_pack/exception/trap/test.s
+++ b/test_pack/exception/trap/test.s
@@ -1,0 +1,28 @@
+.text
+main:
+	li x1, 0xf0000000
+	lui x2, %hi(START_MESSAGE)
+	addi x2, x2, %lo(START_MESSAGE)
+P_START_MESSAGE:
+	lb 	x3, 0(x2)
+	beqz x3, ECALL
+	sb 	x3, 0(x1)
+	j 	P_START_MESSAGE
+ECALL:	
+	ecall
+	lui x2, %hi(CHECK_PASSED)
+	addi x2, x2, %lo(CHECK_PASSED)
+P_END_MESSAGE:
+	lb 	x3, 0(x2)
+	beqz x3, EXIT
+	sb	x3, 0(x1)
+	j P_END_MESSAGE
+EXIT:
+	li x1, 0xff000000
+	sw x0, 0(x1)
+
+START_MESSAGE:
+.string "TRAP TEST\n"
+
+CHECK_PASSED:
+.string "CHECK PASSED!!\n"

--- a/test_pack/exception/trap/test.s
+++ b/test_pack/exception/trap/test.s
@@ -7,6 +7,7 @@ P_START_MESSAGE:
 	lb 	x3, 0(x2)
 	beqz x3, ECALL
 	sb 	x3, 0(x1)
+	addi x2, x2, 1
 	j 	P_START_MESSAGE
 ECALL:	
 	ecall
@@ -16,13 +17,14 @@ P_END_MESSAGE:
 	lb 	x3, 0(x2)
 	beqz x3, EXIT
 	sb	x3, 0(x1)
+	addi x2, x2, 1
 	j P_END_MESSAGE
 EXIT:
 	li x1, 0xff000000
 	sw x0, 0(x1)
 
+.section .rodata
 START_MESSAGE:
 .string "TRAP TEST\n"
-
 CHECK_PASSED:
 .string "CHECK PASSED!!\n"


### PR DESCRIPTION
## Summary 
- add support to ecall instruction
- handle exceptions
  - instruction address misalignment
  - illegal instructions 
- The processor in this PR is not working
  - reason:
    - when deciding not to raise an exception due to a jump in executions, I used the signal `jump_ex` instead of `flush_id`. I should change the statement to "not raise an exception when the pipeline stage is flushed"