### PR TITLE
Add Post ID Stage

### DIFF
--- a/src/ex_ctrl.v
+++ b/src/ex_ctrl.v
@@ -7,14 +7,7 @@ module ex_ctrl (
     input [3:0] ir_type,
     input [2:0] funct3,
     input [6:0] funct7,
-    input [31:0] data1,
-    input [31:0] data2,
-    input [31:0] pc,
-    input [31:0] imm,
-    input [31:0] z_,
 
-    output [31:0] in1,
-    output [31:0] in2,
     output [2:0] branch_alu_op,
     output [3:0] alu_op
 );
@@ -22,7 +15,6 @@ module ex_ctrl (
     // Main
     //
 
-    assign { in1, in2 } = alu_ins_ctrl(ir_type, funct3, data1, data2, pc, imm, z_);
     assign branch_alu_op = branch_alu_op_ctrl(ir_type, funct3);
     assign alu_op = alu_op_ctrl(ir_type, funct3, funct7);
 
@@ -30,53 +22,7 @@ module ex_ctrl (
     // Functions
     //
 
-    // Select the input to ALU
-    // return { in1, in2 }
-    function [63:0] alu_ins_ctrl(
-        input [3:0] ir_type,
-        input [2:0] funct3,
-        input [31:0] data1,
-        input [31:0] data2,
-        input [31:0] pc,
-        input [31:0] imm,
-        input [31:0] z_
-    );
-
-        begin
-            case (ir_type)
-                `LUI_IR: alu_ins_ctrl = { pc, imm };
-
-                `AUIPC_IR: alu_ins_ctrl = { pc, imm };
-
-                `JAL_IR: alu_ins_ctrl = { pc, imm };
-                
-                `JALR_IR: alu_ins_ctrl = { data1, imm };
-
-                `BRANCH_IR: alu_ins_ctrl = { pc, imm };
-
-                `LOAD_IR: alu_ins_ctrl = { data1, imm };
-
-                `STORE_IR: alu_ins_ctrl = { data1, imm };
-
-                `REG_IMM_IR: alu_ins_ctrl = { data1, imm };
-
-                `REG_REG_IR: alu_ins_ctrl = { data1, data2 };
-
-                // mret, ecall
-                `SYS_CALL_IR: alu_ins_ctrl = { z_, imm };
-
-                `CSR_IR: begin
-                    // if (funct3[2] == 1'b1) => csr with imm
-                    // else csr with register
-                    alu_ins_ctrl = (funct3[2] == 1'b1) ? { z_, imm } : { z_, data1 };
-                end
-
-                default: alu_ins_ctrl = { data1, data2 };
-            endcase
-        end
-    endfunction
-
-    function [2:0] branch_alu_op_ctrl(input [3:0] ir_type, input [2:0] funct3);
+        function [2:0] branch_alu_op_ctrl(input [3:0] ir_type, input [2:0] funct3);
         begin
             case (ir_type)
                 `JAL_IR: branch_alu_op_ctrl = `JUMP;

--- a/src/ex_stage.v
+++ b/src/ex_stage.v
@@ -7,19 +7,16 @@ module ex_stage (
     input [3:0] ir_type,
     input [2:0] funct3,
     input [6:0] funct7,
-    input [31:0] pc,
-    input [31:0] data1,
-    input [31:0] data2,
-    input [31:0] imm,
-    input [31:0] z_,
+    input [31:0] alu_in1,
+    input [31:0] alu_in2,
+    input [31:0] branch_alu_in1,
+    input [31:0] branch_alu_in2,
 
     // outputs to MEM stage
     output jump,
     output [31:0] c
 );
 
-    wire [31:0] in1;
-    wire [31:0] in2;
     wire [3:0] alu_op;
     wire [2:0] branch_alu_op;
 
@@ -27,27 +24,20 @@ module ex_stage (
         .ir_type(ir_type),
         .funct3(funct3),
         .funct7(funct7),
-        .data1(data1),
-        .data2(data2),
-        .pc(pc),
-        .imm(imm),
-        .z_(z_),
-        .in1(in1),
-        .in2(in2),
         .branch_alu_op(branch_alu_op),
         .alu_op(alu_op)
     );
 
     alu alu_inst(
-        .in1(in1),
-        .in2(in2),
+        .in1(alu_in1),
+        .in2(alu_in2),
         .alu_op(alu_op),
         .out(c)
     );
 
     branch_alu branch_alu_inst(
-        .in1(data1),
-        .in2(data2),
+        .in1(branch_alu_in1),
+        .in2(branch_alu_in2),
         .branch_alu_op(branch_alu_op),
         .out(jump)
     );

--- a/src/id_ctrl.v
+++ b/src/id_ctrl.v
@@ -1,0 +1,162 @@
+`include "constants/ir_type.v"
+`include "constants/funct3.v"
+`include "constants/imm_type.v"
+`include "imm_extractor.v"
+
+module id_ctrl (
+    input [31:0] ir,
+    input [3:0] ir_type,
+    input [6:0] funct7,
+    input [2:0] funct3,
+    input [4:0] rs1,
+    input [4:0] rd,
+    input is_mret,
+    input is_ecall,
+    input is_return_from_ecall,
+
+    output [31:0] imm,
+    output wr_reg_n,
+    output wr_csr_n,
+    output is_illegal_ir
+);
+
+    //
+    // Main
+    //
+
+    wire [3:0] imm_type = imm_type_from(ir_type, funct3, is_return_from_ecall);
+
+    imm_extractor imm_extractor_inst(
+        .in(ir),
+        .imm_type(imm_type),
+        .out(imm)
+    );
+    
+    assign is_illegal_ir = illegal_ir_check(ir_type, funct3, funct7, is_mret, is_ecall);
+    assign wr_reg_n = wr_reg_n_ctrl(ir_type, rd, is_illegal_ir);
+    assign wr_csr_n = wr_csr_n_ctrl(ir_type, funct3, rs1, is_illegal_ir);
+
+    //
+    // Functions
+    //
+
+    function [3:0] imm_type_from(input [3:0] ir_type, input [2:0] funct3, input is_return_from_ecall);
+        begin
+            case (ir_type)
+                `LUI_IR: imm_type_from = `U_IMM;
+                `AUIPC_IR: imm_type_from = `U_IMM;
+                `JAL_IR: imm_type_from = `J_IMM;
+                `JALR_IR: imm_type_from = `I_IMM;
+                `BRANCH_IR: imm_type_from = `B_IMM;
+                `LOAD_IR: imm_type_from = `I_IMM;
+                `STORE_IR: imm_type_from = `S_IMM;
+                `REG_IMM_IR: begin
+                    // SLLI
+                    if (funct3 == `SLL_FUNCT3) imm_type_from = `SHAMT_IMM;
+                    // SRLI, SRAI
+                    else if (funct3 == `SR_FUNCT3) imm_type_from = `SHAMT_IMM;
+                    // I
+                    else imm_type_from = `I_IMM;
+                end
+                `CSR_IR: imm_type_from = `CSR_IMM;
+                `SYS_CALL_IR: imm_type_from = (is_return_from_ecall) ? `RETURN_FROM_ECALL_IMM : `CSR_IMM;
+                default: imm_type_from = `DEFAULT_IMM;
+            endcase
+        end
+   endfunction
+
+   function wr_reg_n_ctrl(input [3:0] ir_type, input [4:0] rd, input is_illegal_ir);
+        // 0: write, 1: don't write
+        begin
+            // Don't update when IR is illegal
+            // Don't allow write to x0 (always 0)
+            if (is_illegal_ir || (rd == 5'b00000)) begin
+                wr_reg_n_ctrl = 1'b1;
+            end else begin
+                case (ir_type)
+                    `LUI_IR,
+                    `AUIPC_IR,
+                    `REG_IMM_IR,
+                    `REG_REG_IR,
+                    `LOAD_IR,
+                    `JAL_IR,
+                    `JALR_IR,
+                    `CSR_IR: wr_reg_n_ctrl = 1'b0;
+
+                    default: wr_reg_n_ctrl = 1'b1;
+                endcase
+            end
+        end
+    endfunction
+
+    function wr_csr_n_ctrl(input [3:0] ir_type, input [2:0] funct3, input [4:0] rs1, input is_illegal_ir);
+        reg is_csr_ir;
+
+        begin
+            is_csr_ir = (ir_type == `CSR_IR);
+
+            // Don't update when IR is illegal
+            if (is_illegal_ir) wr_csr_n_ctrl = 1'b1;
+            // CSR instructions share the same opcode with ecall, ebreak instructions
+            // ecall and ebreak have funct3 of 000 while CSR instruction doesn't
+            else if (is_csr_ir) begin
+                // Don't update when it's CSRR (pseudo-instruction for CSRRS rd, csr, x0)
+                // is_csrr_ir = (ir_type == `CSR_IR) && (funct3 == `CSRRS_FUNCT3) && (rs1 == 5'b00000)
+                // CSRR doesn't update csr
+                wr_csr_n_ctrl = (funct3 == `CSRRS_FUNCT3) && (rs1 == 5'b00000) ? 1'b1 : 1'b0;
+            end
+            else wr_csr_n_ctrl = 1'b1;
+        end
+    endfunction
+
+    function illegal_ir_check(input [3:0] ir_type, input [2:0] funct3, input [6:0] funct7, input is_mret, input is_ecall);
+        begin
+            case (ir_type)
+                `LUI_IR: illegal_ir_check = 1'b0;
+
+                `AUIPC_IR: illegal_ir_check = 1'b0;
+
+                `JAL_IR: illegal_ir_check = 1'b0;
+
+                `JALR_IR: illegal_ir_check = (funct3 != `JALR_FUNCT3);
+
+                // BRANCH does not have funct3 of { 010, 011 }
+                // funct3 == 010 or 011 is not legal
+                `BRANCH_IR: illegal_ir_check = (funct3 == 3'b010) || (funct3 == 3'b011);
+
+                // LOAD does not have funct3 of { 011, 110, 111 }
+                // funct3 = either of those is not legal
+                `LOAD_IR: illegal_ir_check = (funct3 == 3'b011) || (funct3 == 3'b110) || (funct3 == 3'b111);
+
+                `STORE_IR: illegal_ir_check = (funct3 != `SB_FUNCT3) && (funct3 != `SH_FUNCT3) && (funct3 != `SW_FUNCT3);
+
+                `REG_IMM_IR: begin
+                    // SLLI has funct7 of 0
+                    if (funct3 == `SLL_FUNCT3) illegal_ir_check = (funct7 != 7'b0);
+                    // SRLI, SRAI has funct7 of 0 or 0100000
+                    else if (funct3 == `SR_FUNCT3) illegal_ir_check = (funct7 != 7'b0) && (funct7 != 7'b0100000);
+                    // Else, legal
+                    else illegal_ir_check = 1'b0;
+                end
+
+                `REG_REG_IR: begin
+                    // ADD, SUB has funct7 of 0 or 0100000
+                    // SRL, SRA has funct7 of 0 or 0100000
+                    if ((funct3 == `ADD_FUNCT3) || (funct3 == `SR_FUNCT3)) illegal_ir_check = (funct7 != 7'b0) && (funct7 != 7'b0100000);
+                    // Else has funct7 of 0000000
+                    else illegal_ir_check = (funct7 != 7'b0);
+                end
+
+                // illegal if instruction with funct3 of 000 is not (mret or ecall)
+                `SYS_CALL_IR: illegal_ir_check = !(is_mret || is_ecall);
+
+                //  CSRs instructions does not have funct3 of { 000, 100 }
+                `CSR_IR: illegal_ir_check = (funct3 == `SYS_CALL_FUNCT3) || (funct3 == 3'b100);
+
+                // ir_type is not supported
+                default: illegal_ir_check = 1'b1;
+            endcase
+        end
+    endfunction
+
+endmodule

--- a/src/id_ex_regs.v
+++ b/src/id_ex_regs.v
@@ -33,9 +33,6 @@ module id_ex_regs (
     input [3:0] ir_type_in,
     output [3:0] ir_type_out,
 
-    input [31:0] imm_in,
-    output [31:0] imm_out,
-
     input [31:0] z_in,
     output [31:0] z_out,
 
@@ -52,7 +49,13 @@ module id_ex_regs (
     output jump_prediction_out,
 
     input [31:0] addr_prediction_in,
-    output [31:0] addr_prediction_out
+    output [31:0] addr_prediction_out,
+
+    input [31:0] in1_in,
+    output [31:0] in1_out,
+
+    input [31:0] in2_in,
+    output [31:0] in2_out
 );
 
     reg [31:0] pc;
@@ -63,13 +66,13 @@ module id_ex_regs (
     reg [4:0] rs2, rd;
     reg [11:0] csr_addr;
     reg [3:0] ir_type;
-    reg [31:0] imm;
     reg [31:0] z_;
     reg wr_reg_n;
     reg wr_csr_n;
     reg flush;
     reg jump_prediction;
     reg [31:0] addr_prediction;
+    reg [31:0] in1, in2;
 
     wire stall_or_interlock = stall || interlock;
 
@@ -86,11 +89,14 @@ module id_ex_regs (
             rd <= `DEFAULT_REG;
             csr_addr <= `DEFAULT_CSR_ADDR;
             ir_type <= `DEFAULT_IR_TYPE;
-            imm <= `ZERO_32BIT;
             z_ <= `DEFAULT_Z;
             wr_reg_n <= `DEFAULT_WR_N;
             wr_csr_n <= `DEFAULT_WR_N;
             flush <= `DEFAULT_FLUSH;
+            jump_prediction <= 1'b0;
+            addr_prediction <= `DEFAULT_PC4;
+            in1 <= `ZERO_32BIT;
+            in2 <= `ZERO_32BIT;
         end else if (stall_or_interlock) begin
             // since interlock behaves just like stall
             pc <= pc;
@@ -103,7 +109,6 @@ module id_ex_regs (
             rd <= rd;
             csr_addr <= csr_addr;
             ir_type <= ir_type;
-            imm <= imm;
             z_ <= z_;
             // in order to prevent double detection of stall,
             // which will cause the pipeline to stall forever,
@@ -113,6 +118,8 @@ module id_ex_regs (
             flush <= flush;
             jump_prediction <= jump_prediction;
             addr_prediction <= addr_prediction;
+            in1 <= in1;
+            in2 <= in2;
         end else begin
             pc <= pc_in;
             pc4 <= pc4_in;
@@ -124,13 +131,14 @@ module id_ex_regs (
             rd <= rd_in;
             csr_addr <= csr_addr_in;
             ir_type <= ir_type_in;
-            imm <= imm_in;
             z_ <= z_in;
             wr_reg_n <= wr_reg_n_in;
             wr_csr_n <= wr_csr_n_in;
             flush <= flush_in;
             jump_prediction <= jump_prediction_in;
             addr_prediction <= addr_prediction_in;
+            in1 <= in1_in;
+            in2 <= in2_in;
         end
     end
 
@@ -144,12 +152,13 @@ module id_ex_regs (
     assign csr_addr_out = csr_addr;
     assign rd_out = rd;
     assign ir_type_out = ir_type;
-    assign imm_out = imm;
     assign z_out = z_;
     assign wr_reg_n_out = wr_reg_n;
     assign wr_csr_n_out = wr_csr_n;
     assign flush_out = flush;
     assign jump_prediction_out = jump_prediction;
     assign addr_prediction_out = addr_prediction;
+    assign in1_out = in1;
+    assign in2_out = in2;
     
 endmodule

--- a/src/id_stage.v
+++ b/src/id_stage.v
@@ -1,7 +1,4 @@
-`include "constants/ir_type.v"
-`include "constants/funct3.v"
-`include "constants/imm_type.v"
-`include "imm_extractor.v"
+`include "id_ctrl.v"
 
 module id_stage (
     // inputs from IF stage
@@ -36,16 +33,12 @@ module id_stage (
     // Local Parameters
     //
 
-    localparam [11:0] MEPC_ADDR = 12'h341;
     localparam [31:0] MRET_IR = 32'b0011000_00010_00000_000_00000_1110011;
     localparam [31:0] ECALL_IR = 32'b000000000000_00000_000_00000_1110011;
 
     //
     // Main
     //
-
-    assign is_mret = (ir == MRET_IR);
-    assign is_ecall = (ir == ECALL_IR);
 
     assign rs1 = ir[19:15];
     assign rs2 = ir[24:20];
@@ -54,140 +47,25 @@ module id_stage (
     assign funct7 = ir[31:25];
     assign csr_addr = ir[31:20];
 
-    wire is_return_from_ecall = (is_mret && is_e_cause_eq_ecall);
-    wire [3:0] imm_type = imm_type_from(ir_type, funct3, is_return_from_ecall);
+    assign is_mret = (ir == MRET_IR);
+    assign is_ecall = (ir == ECALL_IR);
 
-    imm_extractor imm_extractor_inst(
-        .in(ir),
-        .imm_type(imm_type),
-        .out(imm)
+    wire is_return_from_ecall = (is_mret && is_e_cause_eq_ecall);
+
+    id_ctrl id_ctrl_inst(
+        .ir(ir),
+        .ir_type(ir_type),
+        .funct7(funct7),
+        .funct3(funct3),
+        .rs1(rs1),
+        .rd(rd),
+        .is_mret(is_mret),
+        .is_ecall(is_ecall),
+        .is_return_from_ecall(is_return_from_ecall),
+        .imm(imm),
+        .wr_reg_n(wr_reg_n),
+        .wr_csr_n(wr_csr_n),
+        .is_illegal_ir(is_illegal_ir)
     );
 
-    assign wr_reg_n = wr_reg_n_ctrl(ir_type, rd, is_illegal_ir);
-    assign wr_csr_n = wr_csr_n_ctrl(ir_type, funct3, rs1, is_illegal_ir);
-
-    assign is_illegal_ir = illegal_ir_check(ir_type, funct3, funct7, is_mret, is_ecall);
-
-    //
-    // Functions
-    //
-
-    function [3:0] imm_type_from(input [3:0] ir_type, input [2:0] funct3, input is_return_from_ecall);
-        begin
-            case (ir_type)
-                `LUI_IR: imm_type_from = `U_IMM;
-                `AUIPC_IR: imm_type_from = `U_IMM;
-                `JAL_IR: imm_type_from = `J_IMM;
-                `JALR_IR: imm_type_from = `I_IMM;
-                `BRANCH_IR: imm_type_from = `B_IMM;
-                `LOAD_IR: imm_type_from = `I_IMM;
-                `STORE_IR: imm_type_from = `S_IMM;
-                `REG_IMM_IR: begin
-                    // SLLI
-                    if (funct3 == `SLL_FUNCT3) imm_type_from = `SHAMT_IMM;
-                    // SRLI, SRAI
-                    else if (funct3 == `SR_FUNCT3) imm_type_from = `SHAMT_IMM;
-                    // I
-                    else imm_type_from = `I_IMM;
-                end
-                `CSR_IR: imm_type_from = `CSR_IMM;
-                `SYS_CALL_IR: imm_type_from = (is_return_from_ecall) ? `RETURN_FROM_ECALL_IMM : `CSR_IMM;
-                default: imm_type_from = `DEFAULT_IMM;
-            endcase
-        end
-   endfunction
-
-   function wr_reg_n_ctrl(input [3:0] ir_type, input [4:0] rd, input is_illegal_ir);
-        // 0: write, 1: don't write
-        begin
-            // Don't update when IR is illegal
-            // Don't allow write to x0 (always 0)
-            if (is_illegal_ir || (rd == 5'b00000)) begin
-                wr_reg_n_ctrl = 1'b1;
-            end else begin
-                case (ir_type)
-                    `LUI_IR,
-                    `AUIPC_IR,
-                    `REG_IMM_IR,
-                    `REG_REG_IR,
-                    `LOAD_IR,
-                    `JAL_IR,
-                    `JALR_IR,
-                    `CSR_IR: wr_reg_n_ctrl = 1'b0;
-
-                    default: wr_reg_n_ctrl = 1'b1;
-                endcase
-            end
-        end
-    endfunction
-
-    function wr_csr_n_ctrl(input [3:0] ir_type, input [2:0] funct3, input [4:0] rs1, input is_illegal_ir);
-        reg is_csr_ir;
-
-        begin
-            is_csr_ir = (ir_type == `CSR_IR);
-
-            // Don't update when IR is illegal
-            if (is_illegal_ir) wr_csr_n_ctrl = 1'b1;
-            // CSR instructions share the same opcode with ecall, ebreak instructions
-            // ecall and ebreak have funct3 of 000 while CSR instruction doesn't
-            else if (is_csr_ir) begin
-                // Don't update when it's CSRR (pseudo-instruction for CSRRS rd, csr, x0)
-                // is_csrr_ir = (ir_type == `CSR_IR) && (funct3 == `CSRRS_FUNCT3) && (rs1 == 5'b00000)
-                // CSRR doesn't update csr
-                wr_csr_n_ctrl = (funct3 == `CSRRS_FUNCT3) && (rs1 == 5'b00000) ? 1'b1 : 1'b0;
-            end
-            else wr_csr_n_ctrl = 1'b1;
-        end
-    endfunction
-
-    function illegal_ir_check(input [3:0] ir_type, input [2:0] funct3, input [6:0] funct7, input is_mret, input is_ecall);
-        begin
-            case (ir_type)
-                `LUI_IR: illegal_ir_check = 1'b0;
-
-                `AUIPC_IR: illegal_ir_check = 1'b0;
-
-                `JAL_IR: illegal_ir_check = 1'b0;
-
-                `JALR_IR: illegal_ir_check = (funct3 != `JALR_FUNCT3);
-
-                // BRANCH does not have funct3 of { 010, 011 }
-                // funct3 == 010 or 011 is not legal
-                `BRANCH_IR: illegal_ir_check = (funct3 == 3'b010) || (funct3 == 3'b011);
-
-                // LOAD does not have funct3 of { 011, 110, 111 }
-                // funct3 = either of those is not legal
-                `LOAD_IR: illegal_ir_check = (funct3 == 3'b011) || (funct3 == 3'b110) || (funct3 == 3'b111);
-
-                `STORE_IR: illegal_ir_check = (funct3 != `SB_FUNCT3) && (funct3 != `SH_FUNCT3) && (funct3 != `SW_FUNCT3);
-
-                `REG_IMM_IR: begin
-                    // SLLI has funct7 of 0
-                    if (funct3 == `SLL_FUNCT3) illegal_ir_check = (funct7 != 7'b0);
-                    // SRLI, SRAI has funct7 of 0 or 0100000
-                    else if (funct3 == `SR_FUNCT3) illegal_ir_check = (funct7 != 7'b0) && (funct7 != 7'b0100000);
-                    // Else, legal
-                    else illegal_ir_check = 1'b0;
-                end
-
-                `REG_REG_IR: begin
-                    // ADD, SUB has funct7 of 0 or 0100000
-                    // SRL, SRA has funct7 of 0 or 0100000
-                    if ((funct3 == `ADD_FUNCT3) || (funct3 == `SR_FUNCT3)) illegal_ir_check = (funct7 != 7'b0) && (funct7 != 7'b0100000);
-                    // Else has funct7 of 0000000
-                    else illegal_ir_check = (funct7 != 7'b0);
-                end
-
-                // illegal if instruction with funct3 of 000 is not (mret or ecall)
-                `SYS_CALL_IR: illegal_ir_check = !(is_mret || is_ecall);
-
-                //  CSRs instructions does not have funct3 of { 000, 100 }
-                `CSR_IR: illegal_ir_check = (funct3 == `SYS_CALL_FUNCT3) || (funct3 == 3'b100);
-
-                // ir_type is not supported
-                default: illegal_ir_check = 1'b1;
-            endcase
-        end
-    endfunction
 endmodule

--- a/src/post_id_stage.v
+++ b/src/post_id_stage.v
@@ -1,0 +1,69 @@
+`include "constants/ir_type.v"
+
+// Prepare the data required by EX stage
+module post_id_stage (
+    input [3:0] ir_type,
+    input [2:0] funct3,
+    input [31:0] data1,
+    input [31:0] data2,
+    input [31:0] pc,
+    input [31:0] imm,
+    input [31:0] z_,
+
+    output [31:0] in1,
+    output [31:0] in2
+);
+
+    assign { in1, in2 } = alu_ins_ctrl(ir_type, funct3, data1, data2, pc, imm, z_);
+    
+    //
+    // Function
+    //
+
+    // Select the input to ALU
+    // return { in1, in2 }
+    function [63:0] alu_ins_ctrl(
+        input [3:0] ir_type,
+        input [2:0] funct3,
+        input [31:0] data1,
+        input [31:0] data2,
+        input [31:0] pc,
+        input [31:0] imm,
+        input [31:0] z_
+    );
+
+        begin
+            case (ir_type)
+                `LUI_IR: alu_ins_ctrl = { pc, imm };
+
+                `AUIPC_IR: alu_ins_ctrl = { pc, imm };
+
+                `JAL_IR: alu_ins_ctrl = { pc, imm };
+                
+                `JALR_IR: alu_ins_ctrl = { data1, imm };
+
+                `BRANCH_IR: alu_ins_ctrl = { pc, imm };
+
+                `LOAD_IR: alu_ins_ctrl = { data1, imm };
+
+                `STORE_IR: alu_ins_ctrl = { data1, imm };
+
+                `REG_IMM_IR: alu_ins_ctrl = { data1, imm };
+
+                `REG_REG_IR: alu_ins_ctrl = { data1, data2 };
+
+                // mret, ecall
+                `SYS_CALL_IR: alu_ins_ctrl = { z_, imm };
+
+                `CSR_IR: begin
+                    // if (funct3[2] == 1'b1) => csr with imm
+                    // else csr with register
+                    alu_ins_ctrl = (funct3[2] == 1'b1) ? { z_, imm } : { z_, data1 };
+                end
+
+                default: alu_ins_ctrl = { data1, data2 };
+            endcase
+        end
+    endfunction
+    
+endmodule

--- a/src/top.v
+++ b/src/top.v
@@ -22,6 +22,7 @@
 `include "mem_stage.v"
 `include "mem_wb_regs.v"
 `include "pc_reg.v"
+`include "post_id_stage.v"
 `include "rf32x32.v"
 `include "stall_detector.v"
 `include "jump_predictor.v"
@@ -77,6 +78,7 @@ module top (
     wire [11:0] csr_addr_id;
     wire [31:0] data1_regfile, data2_regfile;
     wire [31:0] data1_id, data2_id;
+    wire [31:0] in1_id, in2_id;
     wire [31:0] imm_id;
     wire [31:0] z_csrs;
     wire [31:0] z_id;
@@ -91,12 +93,12 @@ module top (
     wire [31:0] pc_from_id;
     wire [31:0] pc4_from_id;
     wire [31:0] data1_from_id, data2_from_id;
+    wire [31:0] in1_from_id, in2_from_id;
     // wire [3:0] ir_type_from_id;
     wire [6:0] funct7_from_id;
     wire [2:0] funct3_from_id;
     wire [4:0] rs2_from_id, rd_from_id;
     wire [11:0] csr_addr_from_id;
-    wire [31:0] imm_from_id;
     wire [31:0] z_from_id;
     wire wr_reg_n_from_id;
     wire wr_csr_n_from_id;
@@ -308,6 +310,18 @@ module top (
         .z_id(z_id)
     );
 
+    post_id_stage post_id_stage_inst(
+        .ir_type(ir_type_from_if),
+        .funct3(funct3_id),
+        .data1(data1_id),
+        .data2(data2_id),
+        .pc(pc_from_if),
+        .imm(imm_id),
+        .z_(z_id),
+        .in1(in1_id),
+        .in2(in2_id)
+    );
+
     // ID-EX
     id_ex_regs id_ex_regs_inst(
         .clk(clk),
@@ -334,8 +348,6 @@ module top (
         .csr_addr_out(csr_addr_from_id),
         .ir_type_in(ir_type_from_if),
         .ir_type_out(ir_type_from_id),
-        .imm_in(imm_id),
-        .imm_out(imm_from_id),
         .z_in(z_id),
         .z_out(z_from_id),
         .wr_reg_n_in(wr_reg_n_id),
@@ -347,7 +359,11 @@ module top (
         .jump_prediction_in(jump_prediction_from_if),
         .jump_prediction_out(jump_prediction_from_id),
         .addr_prediction_in(addr_prediction_from_if),
-        .addr_prediction_out(addr_prediction_from_id)
+        .addr_prediction_out(addr_prediction_from_id),
+        .in1_in(in1_id),
+        .in1_out(in1_from_id),
+        .in2_in(in2_id),
+        .in2_out(in2_from_id)
     );
 
     // EX
@@ -355,11 +371,10 @@ module top (
         .ir_type(ir_type_from_id),
         .funct3(funct3_from_id),
         .funct7(funct7_from_id),
-        .pc(pc_from_id),
-        .data1(data1_from_id),
-        .data2(data2_from_id),
-        .imm(imm_from_id),
-        .z_(z_from_id),
+        .alu_in1(in1_from_id),
+        .alu_in2(in2_from_id),
+        .branch_alu_in1(data1_from_id),
+        .branch_alu_in2(data2_from_id),
         .jump(jump_from_branch_alu),
         .c(c_ex)
     );


### PR DESCRIPTION
## Summary 
Post ID Stage will prepare the inputs required for ALU in ID stage rather than EX stage.
This will shorten the critical path and help in reducing the clock period (time constraint).

📝 Part of #49 